### PR TITLE
Fix #6: correct config loading order and remove SVG upload support

### DIFF
--- a/src/VendlyServer.Api/Dependencies.cs
+++ b/src/VendlyServer.Api/Dependencies.cs
@@ -108,11 +108,11 @@ public static class Dependencies
     {
         _ = builder.Configuration.AddJsonFile(
             Path.Join(AppContext.BaseDirectory,
-                $"appsettings.{builder.Environment.EnvironmentName}.json"),
+                $"appsettings.json"),
             optional: false);
         _ = builder.Configuration.AddJsonFile(
             Path.Join(AppContext.BaseDirectory,
-                $"appsettings.json"),
+                $"appsettings.{builder.Environment.EnvironmentName}.json"),
             optional: false);
         builder.Configuration.AddEnvironmentVariables();
 

--- a/src/VendlyServer.Application/Services/Storage/StorageOptions.cs
+++ b/src/VendlyServer.Application/Services/Storage/StorageOptions.cs
@@ -5,5 +5,5 @@ public class StorageOptions
     public string BasePath { get; set; } = "wwwroot/uploads";
     public string BaseUrl { get; set; } = "/uploads";
     public long MaxFileSizeBytes { get; set; } = 5_242_880;
-    public string[] AllowedExtensions { get; set; } = [".jpg", ".jpeg", ".png", ".webp", ".svg"];
+    public string[] AllowedExtensions { get; set; } = [".jpg", ".jpeg", ".png", ".webp"];
 }


### PR DESCRIPTION
Fixes #6

## Summary

Two security warnings from the automated review, both addressed in this PR:

**1. Inverted appsettings loading order**
In `ConfigureHostConfigurations`, the environment-specific file (`appsettings.{env}.json`) was being loaded *before* the base file (`appsettings.json`). Because ASP.NET Core configuration applies later-added providers with higher priority, this meant the base file silently overrode the env-specific one. The practical impact was that `Hangfire:Dashboard:Password` from `appsettings.json` (`changeme`) was always used in production, because no env-specific file overrides that key. The fix swaps the two `AddJsonFile` calls so base is loaded first and env-specific second.

**2. SVG in `AllowedExtensions` (stored XSS vector)**
SVG is XML and can embed `<script>` tags and `javascript:` hrefs that execute in the browser when served from the same origin. Removing `.svg` from `StorageOptions.AllowedExtensions` eliminates the risk without affecting any of the current raster-image use cases.

## Files changed

- `src/VendlyServer.Api/Dependencies.cs` — swap `AddJsonFile` call order in `ConfigureHostConfigurations`
- `src/VendlyServer.Application/Services/Storage/StorageOptions.cs` — remove `.svg` from `AllowedExtensions`

## Verification

The .NET SDK was not available in this environment so `dotnet build` could not be run. Both changes are mechanical: a two-line swap and a single string removed from an array. No logic changes, no new dependencies, no API contract changes.

## Risks / assumptions

- If any existing feature currently depends on SVG uploads it will start rejecting `.svg` files after this change. A grep of the codebase found no feature that explicitly uploads or references SVG files.
- The Hangfire password fix takes effect immediately on next deploy. The team should also add a strong password to `appsettings.Production.json` under `Hangfire:Dashboard:Password` (or supply it via environment variable) rather than relying solely on the corrected load order to pick up a future override.

---
_Generated by [Claude Code](https://claude.ai/code/session_011HFkc2RaErZHJFTi4WEaYX)_