### PR TITLE
Fix #5: disable Swagger in production and restrict CORS origins

### DIFF
--- a/src/VendlyServer.Api/Dependencies.cs
+++ b/src/VendlyServer.Api/Dependencies.cs
@@ -67,16 +67,19 @@ public static class Dependencies
         return services;
     }
 
-    public static IServiceCollection ConfigureCors(this IServiceCollection services)
+    public static IServiceCollection ConfigureCors(
+        this IServiceCollection services, IConfiguration configuration)
     {
+        var allowedOrigins = configuration.GetSection("Cors:AllowedOrigins").Get<string[]>();
+
         services.AddCors(options =>
         {
             options.AddDefaultPolicy(policy =>
             {
-                policy
-                    .AllowAnyOrigin()
-                    .AllowAnyMethod()
-                    .AllowAnyHeader();
+                if (allowedOrigins is { Length: > 0 })
+                    policy.WithOrigins(allowedOrigins).AllowAnyMethod().AllowAnyHeader();
+                else
+                    policy.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader();
             });
         });
 

--- a/src/VendlyServer.Api/Program.cs
+++ b/src/VendlyServer.Api/Program.cs
@@ -15,14 +15,14 @@ builder.Services
     .ConfigureInfrastructure(builder.Configuration)
     .ConfigureSwagger()
     .ConfigureControllers()
-    .ConfigureCors()
+    .ConfigureCors(builder.Configuration)
     .ConfigureHangfire(builder.Configuration);
 
 builder.ConfigureHostConfigurations();
 
 var app = builder.Build();
 
-if (app.Environment.IsDevelopment() || app.Environment.IsStaging() || app.Environment.IsProduction())
+if (!app.Environment.IsProduction())
 {
     app.UseStaticFiles();
     app.UseSwagger();

--- a/src/VendlyServer.Api/appsettings.Production.json
+++ b/src/VendlyServer.Api/appsettings.Production.json
@@ -5,6 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "Cors": {
+    "AllowedOrigins": [ "https://vestor.uz", "https://www.vestor.uz" ]
+  },
   "ConnectionStrings": {
     "DefaultConnectionString": "Host=host.docker.internal;Port=5432;Database=prod_vendly_db;Username=postgres;Password=K@3wF!8zQ2#eRt"
   },

--- a/src/VendlyServer.Api/appsettings.Staging.json
+++ b/src/VendlyServer.Api/appsettings.Staging.json
@@ -5,6 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "Cors": {
+    "AllowedOrigins": [ "https://vestor.uz", "https://www.vestor.uz" ]
+  },
   "ConnectionStrings": {
     "DefaultConnectionString": "Host=host.docker.internal;Port=5432;Database=stage_vendly_db;Username=postgres;Password=K@3wF!8zQ2#eRt"
   },


### PR DESCRIPTION
Fixes #5

## Summary

Two medium-severity security findings from the automated review, both addressed in this PR:

**1. Swagger/Scalar UI exposed in production**
`Program.cs` was enabling the Swagger and Scalar endpoints for all three environments including Production. This exposes the full OpenAPI schema (all route paths, shapes, auth schemes, enum values) publicly. The fix changes the guard from an explicit allowlist of all three environments to `!app.Environment.IsProduction()`, so Swagger is served in Development and Staging only.

**2. Wildcard CORS policy in production**
`ConfigureCors` unconditionally used `AllowAnyOrigin()` for all environments. The fix makes allowed origins configuration-driven via `Cors:AllowedOrigins` in appsettings. When the list is non-empty, `WithOrigins(...)` is used (restricting cross-origin access to known clients); when the list is absent or empty the policy falls back to wildcard, preserving the current Development behaviour with no config change required. `appsettings.Production.json` and `appsettings.Staging.json` are updated to set `https://vestor.uz` and `https://www.vestor.uz` as the allowed origins, based on the existing `Minio:PublicBaseUrl` evidence in those files.

## Files changed

- `src/VendlyServer.Api/Program.cs` — replace three-environment guard with `!IsProduction()`; pass `builder.Configuration` to `ConfigureCors`
- `src/VendlyServer.Api/Dependencies.cs` — make `ConfigureCors` accept `IConfiguration` and conditionally use `WithOrigins`
- `src/VendlyServer.Api/appsettings.Production.json` — add `Cors:AllowedOrigins`
- `src/VendlyServer.Api/appsettings.Staging.json` — add `Cors:AllowedOrigins`

## Verification

The .NET SDK was not available in this environment so `dotnet build` could not be run. The changes are straightforward: one condition change, one method signature extension, and two JSON entries.

## Risks / assumptions

- **CORS origins**: `vestor.uz` is inferred from `Minio:PublicBaseUrl`. If the actual frontend domain differs, update `Cors:AllowedOrigins` in the relevant appsettings before deploying. The fallback to wildcard when the list is empty means an accidental deploy with an empty list would silently revert to the old behaviour rather than blocking all requests.
- **Swagger in Staging**: the team may want Swagger available in Staging for QA. The current fix keeps it enabled there. Adjust if that is not desired.

---
_Generated by [Claude Code](https://claude.ai/code/session_011HFkc2RaErZHJFTi4WEaYX)_