### PR TITLE
Fix #20: fail closed in Telegram webhook when secret token is not configured

### DIFF
--- a/src/VendlyServer.Api/Controllers/Public/TelegramController.cs
+++ b/src/VendlyServer.Api/Controllers/Public/TelegramController.cs
@@ -32,7 +32,7 @@ public sealed class TelegramController(
     private bool IsValidSecretToken()
     {
         if (string.IsNullOrWhiteSpace(_options.WebhookSecretToken))
-            return true;
+            return false;
 
         return Request.Headers.TryGetValue(SecretTokenHeaderName, out var actualSecretToken) &&
                string.Equals(actualSecretToken.ToString(), _options.WebhookSecretToken, StringComparison.Ordinal);


### PR DESCRIPTION
Fixes #20 (Finding 2)

## Summary

`TelegramController.IsValidSecretToken()` returned `true` (accepted all requests) when `TelegramBot:WebhookSecretToken` was absent or blank. This meant the `/api/telegram/webhook` endpoint was wide open to anyone who discovered the URL, allowing crafted `TelegramUpdate` payloads to trigger product searches and bot message sends without authentication.

Changed the fallback from `return true` to `return false` so the endpoint rejects all requests until a secret token is configured — a single-character fix that closes the vulnerability.

**Finding 1 (rate limiting on `/api/currency/convert`) from the same issue is not addressed here.** Adding ASP.NET Core rate-limiting middleware requires a broader configuration decision (policy shape, per-IP vs global, burst limits) that is out of scope for a bounded automated fix. It should be tracked separately.

## Files changed

- `src/VendlyServer.Api/Controllers/Public/TelegramController.cs` — `IsValidSecretToken()`: `return true` → `return false` when token is empty

## Verification

`dotnet` SDK was not available in this environment. The change is a single boolean literal replacement with no logic branches added; no behaviour change occurs on the success path (when a valid token is configured).

## Risks / assumptions

- Any environment that currently runs with `WebhookSecretToken` absent or blank will now receive `401 Unauthorized` on every webhook POST. Configure `TelegramBot:WebhookSecretToken` (e.g. via environment variable) before deploying to avoid breaking the bot integration.
- This does not add a startup guard that throws when `Enabled = true` but the token is missing; that hardening can follow separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkZNKkrQMUDvy2bosLoasw)_