### PR TITLE
Fix #21: block RFC 1918 and link-local IPs in Telegram SSRF guard

### DIFF
--- a/src/VendlyServer.Application/Services/Telegram/TelegramUpdateHandler.cs
+++ b/src/VendlyServer.Application/Services/Telegram/TelegramUpdateHandler.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Net;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using VendlyServer.Application;
@@ -176,8 +177,25 @@ public sealed class TelegramUpdateHandler(
         if (uri.Scheme is not ("http" or "https"))
             return false;
 
-        return !uri.IsLoopback &&
-               !string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase);
+        if (uri.IsLoopback || string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (IPAddress.TryParse(uri.Host, out var ip) && IsPrivateOrReservedIp(ip))
+            return false;
+
+        return true;
+    }
+
+    private static bool IsPrivateOrReservedIp(IPAddress ip)
+    {
+        var bytes = ip.GetAddressBytes();
+        return ip.IsIPv6LinkLocal
+            || ip.IsIPv6SiteLocal
+            || (bytes.Length == 4 && (
+                bytes[0] == 10
+                || (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31)
+                || (bytes[0] == 192 && bytes[1] == 168)
+                || (bytes[0] == 169 && bytes[1] == 254)));
     }
 
     private Dictionary<string, object?> BuildArticleResult(ProductSearchResponse product, string? imageUrl = null)


### PR DESCRIPTION
Fixes #21

## Summary

`IsTelegramFetchableImageUrl` in `TelegramUpdateHandler` only blocked `127.0.0.1` (via `IsLoopback`) and the literal hostname `localhost`. RFC 1918 private ranges (`10.x.x.x`, `172.16–31.x.x`, `192.168.x.x`), the cloud metadata address (`169.254.169.254`), and other link-local addresses were reachable. An attacker with product admin or sync access who could write an internal IP address into a product's image URL could cause the server to make an outbound HEAD request to an internal endpoint via the Telegram image-validation flow.

**Changes:**

- Added `IsPrivateOrReservedIp(IPAddress ip)` helper that matches IPv4 private ranges (10/8, 172.16/12, 192.168/16) and link-local (169.254/16), plus IPv6 link-local and site-local.
- Updated `IsTelegramFetchableImageUrl` to parse the host as an IP address and reject it if `IsPrivateOrReservedIp` returns `true`.
- Added `using System.Net;` for `IPAddress`.

Hostname-based checks (DNS resolution at validation time, DNS rebinding protection) are a deeper fix left for a follow-up; this PR closes the most direct attack vector where an IP literal is stored in the DB.

## Files changed

- `src/VendlyServer.Application/Services/Telegram/TelegramUpdateHandler.cs` — added `IsPrivateOrReservedIp`, updated `IsTelegramFetchableImageUrl`

## Verification

`dotnet` SDK was not available in this environment. The logic is pure in-memory IP byte comparison with no I/O; the change only affects the `IsTelegramFetchableImageUrl` predicate used to filter image URLs before the outbound HEAD request.

## Risks / assumptions

- Image URLs stored as IP literals pointing to private ranges will now be silently skipped (no thumbnail in Telegram results). This is the intended behaviour.
- Hostnames that resolve to private IPs are still not blocked (DNS rebinding / split-horizon DNS). A custom `DelegatingHandler` that resolves and re-checks the IP before every request would close this gap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkZNKkrQMUDvy2bosLoasw)_