### PR TITLE
Fix #22: fetch only needed currency rate; add expired refresh token cleanup job

### DIFF
--- a/src/VendlyServer.Application/Dependencies.cs
+++ b/src/VendlyServer.Application/Dependencies.cs
@@ -2,6 +2,7 @@ using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Minio;
+using VendlyServer.Application.Jobs.Auth;
 using VendlyServer.Application.Jobs.BtsCatalog;
 using VendlyServer.Application.Services.Auth;
 using VendlyServer.Application.Services.BtsRef;
@@ -35,6 +36,7 @@ public static class Dependencies
         services.AddScoped<ICurrencyConverterService, CurrencyConverterService>();
 
         services.AddScoped<IBtsCatalogSyncJob, BtsCatalogSyncJob>();
+        services.AddScoped<ICleanExpiredRefreshTokensJob, CleanExpiredRefreshTokensJob>();
 
         return services;
     }

--- a/src/VendlyServer.Application/Jobs/Auth/CleanExpiredRefreshTokensJob.cs
+++ b/src/VendlyServer.Application/Jobs/Auth/CleanExpiredRefreshTokensJob.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using VendlyServer.Infrastructure.Persistence;
+
+namespace VendlyServer.Application.Jobs.Auth;
+
+public class CleanExpiredRefreshTokensJob(
+    AppDbContext dbContext,
+    ILogger<CleanExpiredRefreshTokensJob> logger) : ICleanExpiredRefreshTokensJob
+{
+    private const int RevokedRetentionDays = 7;
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        var now = DateTime.UtcNow;
+        var revokedCutoff = now.AddDays(-RevokedRetentionDays);
+
+        var deleted = await dbContext.RefreshTokens
+            .Where(rt => rt.ExpiresAt < now || (rt.IsRevoked && rt.UpdatedAt < revokedCutoff))
+            .ExecuteDeleteAsync(cancellationToken);
+
+        logger.LogInformation(
+            "Refresh token cleanup: deleted {Count} expired/revoked tokens at {RunAt}",
+            deleted,
+            now);
+    }
+}

--- a/src/VendlyServer.Application/Jobs/Auth/ICleanExpiredRefreshTokensJob.cs
+++ b/src/VendlyServer.Application/Jobs/Auth/ICleanExpiredRefreshTokensJob.cs
@@ -1,0 +1,6 @@
+namespace VendlyServer.Application.Jobs.Auth;
+
+public interface ICleanExpiredRefreshTokensJob
+{
+    Task ExecuteAsync(CancellationToken cancellationToken = default);
+}

--- a/src/VendlyServer.Application/Jobs/JobsRegistrar.cs
+++ b/src/VendlyServer.Application/Jobs/JobsRegistrar.cs
@@ -1,4 +1,5 @@
 using Hangfire;
+using VendlyServer.Application.Jobs.Auth;
 using VendlyServer.Application.Jobs.BtsCatalog;
 
 namespace VendlyServer.Application.Jobs;
@@ -12,5 +13,10 @@ public static class JobsRegistrar
         //     "bts-catalog-sync",
         //     job => job.ExecuteAsync(CancellationToken.None),
         //     Cron.Weekly(DayOfWeek.Sunday, 3));
+
+        RecurringJob.AddOrUpdate<ICleanExpiredRefreshTokensJob>(
+            "clean-expired-refresh-tokens",
+            job => job.ExecuteAsync(CancellationToken.None),
+            Cron.Daily(hour: 2));
     }
 }

--- a/src/VendlyServer.Application/Services/Currency/CurrencyApiClient.cs
+++ b/src/VendlyServer.Application/Services/Currency/CurrencyApiClient.cs
@@ -9,7 +9,7 @@ public class CurrencyApiClient(HttpClient httpClient, ILogger<CurrencyApiClient>
     {
         try
         {
-            var response = await httpClient.GetAsync("latest", cancellationToken);
+            var response = await httpClient.GetAsync($"latest?currencies={Uri.EscapeDataString(currencyCode.ToUpperInvariant())}", cancellationToken);
 
             if (!response.IsSuccessStatusCode)
             {


### PR DESCRIPTION
Fixes #22

## Summary

Two code quality issues from the automated review, both addressed here:

**1. CurrencyApiClient fetched all ~170 rates on every cache miss**

`GetExchangeRateAsync` called `/latest` with no filter, receiving the full rate map and discarding all but one currency. A subsequent call for a different currency triggered another full fetch even though the first response already contained the needed rate.

Fix: pass `?currencies={code}` to the freecurrencyapi.com `/latest` endpoint (documented query parameter). Each call now fetches exactly one currency, reducing response size and eliminating unnecessary paid-API quota consumption. The currency code is URL-encoded via `Uri.EscapeDataString` before interpolation.

**2. Revoked/expired refresh tokens accumulated indefinitely**

`RefreshTokenAsync` marks old tokens as `IsRevoked = true` and inserts a new row, but never removes old rows. Over time this causes unbounded table growth and slower queries.

Fix: add `CleanExpiredRefreshTokensJob` — a Hangfire recurring job (daily at 02:00 UTC) that hard-deletes `RefreshToken` rows where:
- `ExpiresAt < now` (expired — can never be used again), or
- `IsRevoked = true` and `UpdatedAt < now - 7 days` (past the token-reuse detection window)

The job follows the existing `BtsCatalogSyncJob` pattern and is registered in `JobsRegistrar` and the DI container.

## Files changed

- `src/VendlyServer.Application/Services/Currency/CurrencyApiClient.cs` — add `?currencies=` query parameter
- `src/VendlyServer.Application/Jobs/Auth/ICleanExpiredRefreshTokensJob.cs` — new interface
- `src/VendlyServer.Application/Jobs/Auth/CleanExpiredRefreshTokensJob.cs` — new Hangfire job implementation
- `src/VendlyServer.Application/Jobs/JobsRegistrar.cs` — register recurring job
- `src/VendlyServer.Application/Dependencies.cs` — register job in DI

## Verification

`dotnet` SDK was not available in this environment. Changes are additive: the currency fix is a URL string change; the cleanup job uses `ExecuteDeleteAsync` (EF Core 7+, available in this project's EF Core 10 dependency) with a straightforward predicate.

## Risks / assumptions

- **Currency**: the `?currencies=` parameter is supported by freecurrencyapi.com. If the API key is on a plan that does not support filtering, the request will fail with a non-success status code and the service will return `CurrencyErrors.ProviderUnavailable` (existing error path — no new failure modes).
- **Token cleanup**: uses `ExecuteDeleteAsync` which bypasses EF change tracking and issues a direct `DELETE` — appropriate for bulk cleanup. The 7-day revoked-token retention window is conservative; adjust `RevokedRetentionDays` in `CleanExpiredRefreshTokensJob` if a shorter or longer window is preferred.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkZNKkrQMUDvy2bosLoasw)_