### PR TITLE
Fix #6: correct config loading order and remove SVG upload support

### DIFF
--- a/src/VendlyServer.Api/Dependencies.cs
+++ b/src/VendlyServer.Api/Dependencies.cs
@@ -108,11 +108,11 @@ public static class Dependencies
     {
         _ = builder.Configuration.AddJsonFile(
             Path.Join(AppContext.BaseDirectory,
-                $"appsettings.{builder.Environment.EnvironmentName}.json"),
+                $"appsettings.json"),
             optional: false);
         _ = builder.Configuration.AddJsonFile(
             Path.Join(AppContext.BaseDirectory,
-                $"appsettings.json"),
+                $"appsettings.{builder.Environment.EnvironmentName}.json"),
             optional: false);
         builder.Configuration.AddEnvironmentVariables();
 

--- a/src/VendlyServer.Application/Services/Storage/StorageOptions.cs
+++ b/src/VendlyServer.Application/Services/Storage/StorageOptions.cs
@@ -5,5 +5,5 @@ public class StorageOptions
     public string BasePath { get; set; } = "wwwroot/uploads";
     public string BaseUrl { get; set; } = "/uploads";
     public long MaxFileSizeBytes { get; set; } = 5_242_880;
-    public string[] AllowedExtensions { get; set; } = [".jpg", ".jpeg", ".png", ".webp", ".svg"];
+    public string[] AllowedExtensions { get; set; } = [".jpg", ".jpeg", ".png", ".webp"];
 }


### PR DESCRIPTION
Fixes #6

## Summary

Two security warnings from the automated review, both addressed in this PR:

**1. Inverted appsettings loading order**

`ConfigureHostConfigurations` in `Dependencies.cs` loaded the environment-specific file (`appsettings.{env}.json`) *before* the base file (`appsettings.json`). Because ASP.NET Core configuration applies later-added providers with higher priority, the base file silently overrode env-specific settings. The practical impact: `Hangfire:Dashboard:Password` from `appsettings.json` (`changeme`) was always used in production because no env-specific file overrides that key.

Fix: swap the two `AddJsonFile` calls so base is loaded first and env-specific second — the standard ASP.NET Core convention.

**2. SVG in `AllowedExtensions` (stored XSS vector)**

SVG is an XML-based format that supports embedded `<script>` tags. When served from the same origin as the API, a stored SVG file can execute arbitrary JavaScript in a user's browser. Removed `.svg` from `StorageOptions.AllowedExtensions`.

## Files changed

- `src/VendlyServer.Api/Dependencies.cs` — swap `AddJsonFile` call order in `ConfigureHostConfigurations`
- `src/VendlyServer.Application/Services/Storage/StorageOptions.cs` — remove `.svg` from `AllowedExtensions`

## Verification

`dotnet build` — no SDK available in this environment. Changes are minimal and surgical: a two-line swap and a single array element removal. No logic branches added.

## Risks / assumptions

- **Hangfire password**: after this fix, `appsettings.Production.json` and `appsettings.Staging.json` will correctly override `Hangfire:Dashboard:Password`. Those files currently do not define that key, so the `changeme` default from `appsettings.json` still applies until a strong password is added to the env-specific files (or supplied via environment variable).
- **SVG removal**: any existing SVG files already stored will remain; this only blocks future uploads. If SVG support is genuinely needed (e.g. logos), consider serving them from a sandboxed origin or processing them through a sanitiser before storage.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYtNptYjGFWqdkLes9NryT)_