### PR TITLE
Fix #30: bind Seq ports to localhost and move admin passwords to secrets

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -179,11 +179,11 @@ jobs:
                 container_name: vendly-seq-staging
                 restart: unless-stopped
                 ports:
-                  - "5342:5341"
-                  - "8083:80"
+                  - "127.0.0.1:5342:5341"
+                  - "127.0.0.1:8083:80"
                 environment:
                   - ACCEPT_EULA=Y
-                  - SEQ_FIRSTRUN_ADMINPASSWORD=Vendly@SeqStage2026!
+                  - SEQ_FIRSTRUN_ADMINPASSWORD=${{ secrets.SEQ_STAGE_ADMIN_PASSWORD }}
                 volumes:
                   - seq-staging-data:/data
                 networks:
@@ -252,11 +252,11 @@ jobs:
                 container_name: vendly-seq-prod
                 restart: unless-stopped
                 ports:
-                  - "5341:5341"
-                  - "8082:80"
+                  - "127.0.0.1:5341:5341"
+                  - "127.0.0.1:8082:80"
                 environment:
                   - ACCEPT_EULA=Y
-                  - SEQ_FIRSTRUN_ADMINPASSWORD=Vendly@SeqProd2026!
+                  - SEQ_FIRSTRUN_ADMINPASSWORD=${{ secrets.SEQ_PROD_ADMIN_PASSWORD }}
                 volumes:
                   - seq-prod-data:/data
                 networks:


### PR DESCRIPTION
Fixes #30

## Summary

Two medium-severity security findings from the automated review, both addressed in this PR:

**1. Seq ports bound to 0.0.0.0 (all interfaces)**

The staging and production Seq containers used bare port mappings (`"5342:5341"`, `"8083:80"`, `"5341:5341"`, `"8082:80"`), which Docker maps to `0.0.0.0` by default — making the Seq log viewer UI and log ingestion endpoint reachable from the internet. MinIO ports were already correctly bound to `127.0.0.1`; this PR applies the same pattern to all four Seq port mappings.

**2. Seq admin passwords hardcoded in the workflow YAML**

`SEQ_FIRSTRUN_ADMINPASSWORD` was set to literal password strings (`Vendly@SeqStage2026!` / `Vendly@SeqProd2026!`) committed in plaintext. These are replaced with GitHub Actions secret references: `${{ secrets.SEQ_STAGE_ADMIN_PASSWORD }}` and `${{ secrets.SEQ_PROD_ADMIN_PASSWORD }}`.

> **Action required before merging**: add `SEQ_STAGE_ADMIN_PASSWORD` and `SEQ_PROD_ADMIN_PASSWORD` to the repository's GitHub Secrets (Settings → Secrets and variables → Actions). If these secrets are absent when the workflow runs, Seq will start with a blank admin password — which may allow unauthenticated access if the Seq UI is reachable.

## Files changed

- `.github/workflows/ci-cd.yml` — `deploy_staging` and `deploy_prod` jobs: add `127.0.0.1:` prefix to all Seq port mappings; replace hardcoded passwords with secret references

## Verification

YAML-only change; no application code affected. The port binding format `"127.0.0.1:host:container"` is standard Docker Compose syntax, matching the existing MinIO port configuration in the same file.

## Risks / assumptions

- **Pre-merge**: the two GitHub Secrets must be created before this workflow runs. Merging without adding the secrets will result in Seq starting with a blank/empty first-run password.
- **Port access**: after this change, the Seq UI (ports 8082/8083) and ingestion endpoint (5341/5342) are only accessible from localhost. To use the Seq UI, access it via an SSH tunnel (e.g. `ssh -L 8082:127.0.0.1:8082 user@server`) or configure a reverse proxy with authentication.
- **Existing containers**: running `docker compose down && docker compose up` (which the workflow already does) will recreate the containers with the new port bindings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYtNptYjGFWqdkLes9NryT)_