### PR TITLE
Fix #35: derive MinIO object ContentType from file extension, not client header

### DIFF
--- a/src/VendlyServer.Application/Services/Storage/MinioStorageService.cs
+++ b/src/VendlyServer.Application/Services/Storage/MinioStorageService.cs
@@ -13,6 +13,15 @@ public class MinioStorageService(
     private readonly MinioOptions _minio = minioOptions.Value;
     private readonly StorageOptions _storage = storageOptions.Value;
 
+    private static readonly Dictionary<string, string> MimeMap = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [".jpg"]  = "image/jpeg",
+        [".jpeg"] = "image/jpeg",
+        [".png"]  = "image/png",
+        [".webp"] = "image/webp",
+        [".svg"]  = "image/svg+xml",
+    };
+
     public async Task<Result<string>> UploadAsync(
         IFormFile file,
         string folder,
@@ -28,6 +37,7 @@ public class MinioStorageService(
 
         var fileName = $"{Guid.NewGuid()}{extension}";
         var objectKey = $"{folder.Trim('/')}/{fileName}";
+        var contentType = MimeMap.TryGetValue(extension, out var mime) ? mime : "application/octet-stream";
 
         try
         {
@@ -38,7 +48,7 @@ public class MinioStorageService(
                 .WithObject(objectKey)
                 .WithStreamData(stream)
                 .WithObjectSize(file.Length)
-                .WithContentType(file.ContentType ?? "application/octet-stream");
+                .WithContentType(contentType);
 
             await minioClient.PutObjectAsync(args, cancellationToken);
         }


### PR DESCRIPTION
Fixes #35

## Summary

`MinioStorageService.UploadAsync` was passing `file.ContentType` — the `Content-Type` header from the client's multipart form-data part — directly to MinIO as the stored object's content type. Because this value is controlled by the HTTP client, an attacker could upload a file named `exploit.jpg` (passing the extension allowlist) while declaring `Content-Type: text/html` with an HTML/JS body. The object would be stored in MinIO with `Content-Type: text/html` and, given the buckets' anonymous-download access policy (tracked in issue #31), any browser fetching the URL would execute the payload as a stored XSS.

**Fix:** A server-side `MimeMap` dictionary is added that maps each allowed extension to its canonical MIME type. `UploadAsync` now derives `contentType` from the validated extension rather than from `file.ContentType`. The client-supplied header is completely ignored for this purpose.

```csharp
private static readonly Dictionary<string, string> MimeMap = new(StringComparer.OrdinalIgnoreCase)
{
    [".jpg"]  = "image/jpeg",
    [".jpeg"] = "image/jpeg",
    [".png"]  = "image/png",
    [".webp"] = "image/webp",
    [".svg"]  = "image/svg+xml",
};

// In UploadAsync, after extension validation:
var contentType = MimeMap.TryGetValue(extension, out var mime) ? mime : "application/octet-stream";
```

The fallback to `application/octet-stream` is a safety net only; in practice every extension in `AllowedExtensions` is covered by `MimeMap`, so a legitimate upload always gets a known image MIME type.

## Files changed

- `src/VendlyServer.Application/Services/Storage/MinioStorageService.cs` — add `MimeMap`; replace `file.ContentType ?? "application/octet-stream"` with the map lookup

## Verification commands

```
dotnet build
```

The .NET SDK was not available in this environment. The change is confined to one expression in `UploadAsync`; no control flow, signatures, or dependencies are altered.

## Remaining risks / assumptions

- **SVG**: `.svg` is mapped to `image/svg+xml`. SVG still carries stored-XSS risk when served inline by a browser even with the correct MIME type; PR #32 removes SVG from `AllowedExtensions` entirely and is the recommended follow-up.
- **Existing objects**: objects already stored in MinIO retain their old `Content-Type` metadata. Re-upload is required to correct them, but this is outside the scope of a code fix.
- **MimeMap sync**: if `AllowedExtensions` is extended in `StorageOptions`, `MimeMap` should be updated in the same commit to keep them in sync.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXPUNqzLD4kkMt7qXbnF2V)_