### PR TITLE
Fix #34: hash refresh tokens with SHA-256 before persisting to database

### DIFF
--- a/src/VendlyServer.Application/Services/Auth/AuthService.cs
+++ b/src/VendlyServer.Application/Services/Auth/AuthService.cs
@@ -55,9 +55,11 @@ public class AuthService(
 
     public async Task<Result<AuthResponse>> RefreshTokenAsync(RefreshTokenRequest request, CancellationToken cancellationToken = default)
     {
+        var tokenHash = HashToken(request.RefreshToken);
+
         var stored = await dbContext.RefreshTokens
             .Include(rt => rt.User)
-            .SingleOrDefaultAsync(rt => rt.Token == request.RefreshToken && !rt.IsDeleted, cancellationToken);
+            .SingleOrDefaultAsync(rt => rt.Token == tokenHash && !rt.IsDeleted, cancellationToken);
 
         if (stored is null || stored.IsRevoked || stored.ExpiresAt < DateTime.UtcNow)
             return AuthErrors.InvalidRefreshToken;
@@ -76,7 +78,7 @@ public class AuthService(
         dbContext.RefreshTokens.Add(new RefreshToken
         {
             UserId    = stored.User.Id,
-            Token     = rawToken,
+            Token     = HashToken(rawToken),
             ExpiresAt = DateTime.UtcNow.AddDays(30)
         });
 
@@ -87,8 +89,10 @@ public class AuthService(
 
     public async Task<Result> LogoutAsync(string refreshToken, CancellationToken cancellationToken = default)
     {
+        var tokenHash = HashToken(refreshToken);
+
         var stored = await dbContext.RefreshTokens
-            .SingleOrDefaultAsync(rt => rt.Token == refreshToken && !rt.IsDeleted, cancellationToken);
+            .SingleOrDefaultAsync(rt => rt.Token == tokenHash && !rt.IsDeleted, cancellationToken);
 
         if (stored is null || stored.IsRevoked)
             return Result.Success();
@@ -117,7 +121,7 @@ public class AuthService(
         dbContext.RefreshTokens.Add(new RefreshToken
         {
             UserId    = user.Id,
-            Token     = rawToken,
+            Token     = HashToken(rawToken),
             ExpiresAt = DateTime.UtcNow.AddDays(30)
         });
 
@@ -125,6 +129,9 @@ public class AuthService(
 
         return new AuthResponse(accessToken, rawToken, ToUserInfo(user));
     }
+
+    private static string HashToken(string rawToken) =>
+        Convert.ToBase64String(SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(rawToken)));
 
     private static UserInfo ToUserInfo(User user) =>
         new(user.Id, user.FirstName, user.LastName, user.Email, user.Phone, user.Role.ToString().ToLowerInvariant());


### PR DESCRIPTION
Fixes #34

## Summary

`AuthService` was storing the raw base64 refresh token directly in `RefreshTokens.Token`. A database breach (SQL injection, backup leak, misconfigured connection) would expose every active refresh token verbatim, allowing an attacker to impersonate any logged-in user for up to 30 days — including admin and manager sessions. Passwords are correctly hashed with PBKDF2, but the same protection was absent for refresh tokens.

**Fix:** A private `HashToken` helper applies SHA-256 to the raw token string and stores the base64-encoded hash. The raw token is still returned to the client and expected back on `refresh`/`logout` calls; the server hashes the incoming value before the DB lookup. The hash is one-way and non-reversible, so a stolen DB snapshot cannot be used to call the API.

```csharp
private static string HashToken(string rawToken) =>
    Convert.ToBase64String(SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(rawToken)));
```

Three code paths updated:
- **`CreateAuthResponseAsync`** — hashes before inserting; returns raw token to client
- **`RefreshTokenAsync`** — hashes the incoming token before the `SingleOrDefaultAsync` lookup; hashes the new token before inserting
- **`LogoutAsync`** — hashes the incoming token before the `SingleOrDefaultAsync` lookup

**Note on rate limiting (Finding 2 from issue #34):** The absence of rate limiting on `/api/auth/login`, `/api/auth/register`, and `/api/auth/refresh` is a real risk but requires a configuration decision (policy shape, per-IP vs global, burst limits). It is out of scope for this bounded fix and should be tracked as a separate task.

## Files changed

- `src/VendlyServer.Application/Services/Auth/AuthService.cs` — add `HashToken`; update `CreateAuthResponseAsync`, `RefreshTokenAsync`, `LogoutAsync`

## Verification commands

```
dotnet build
```

The .NET SDK was not available in this environment. `SHA256.HashData` is available in `System.Security.Cryptography` (already imported) on .NET 5+. No new packages or migrations are required — `RefreshTokens.Token` column type (string) is unchanged; only the stored value changes from raw base64 (~44 chars) to hashed base64 (~44 chars).

## Remaining risks / assumptions

- **Session invalidation on deploy:** All currently active refresh tokens stored in the database are in plaintext. After this change is deployed, existing tokens will not match their stored hashes and all active sessions will effectively be logged out. Users will need to log in again. This is the correct and expected behaviour for a security fix of this kind.
- **No migration needed:** The `Token` column length (string) accommodates both the raw and hashed values without schema change.
- **Rate limiting:** Still absent on auth endpoints (see issue #34, Finding 2). Track separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXPUNqzLD4kkMt7qXbnF2V)_