### PR TITLE
Fix #38: apply Admin,Manager role baseline on AdminController

### DIFF
--- a/src/VendlyServer.Api/Controllers/Common/AdminController.cs
+++ b/src/VendlyServer.Api/Controllers/Common/AdminController.cs
@@ -1,5 +1,8 @@
+using Microsoft.AspNetCore.Authorization;
+
 namespace VendlyServer.Api.Controllers.Common;
 
+[Authorize(Roles = "Admin,Manager")]
 public abstract class AdminController : AuthorizedController
 {
 }


### PR DESCRIPTION
Fixes #38

## Summary

`AdminController` inherited `[Authorize]` from `AuthorizedController` but carried no role restriction of its own. Any future controller that extends `AdminController` without adding an explicit `[Authorize(Roles = ...)]` on each action would be reachable by any authenticated user — including `Customer` role — with no compile-time or startup warning.

**Fix:** `[Authorize(Roles = "Admin,Manager")]` is applied at the `AdminController` class level, establishing it as the least-privilege baseline. Actions requiring stricter access (e.g. Admin-only operations) can still override the attribute on individual actions, as `UsersController.AssignRoleAsync` already does with `[Authorize(Roles = "Admin")]`.

This converts the pattern from **"must remember to add a role"** (fragile) to **"must remember to relax the role"** (safe by default).

```csharp
[Authorize(Roles = "Admin,Manager")]
public abstract class AdminController : AuthorizedController
{
}
```

### Note on existing `UsersController`

`UsersController` currently extends `AuthorizedController` directly (not `AdminController`) and has per-action role attributes. That controller is unaffected by this change. No refactor of existing controllers is included to keep this fix bounded to the issue.

## Files changed

- `src/VendlyServer.Api/Controllers/Common/AdminController.cs` — add `using Microsoft.AspNetCore.Authorization` and `[Authorize(Roles = "Admin,Manager")]`

## Verification

The .NET SDK was not available in this environment so `dotnet build` could not be run. The change is a one-attribute addition to an abstract class. The `[Authorize(Roles = ...)]` attribute and `Microsoft.AspNetCore.Authorization` namespace are already used throughout the project (e.g. `AuthorizedController`, `UsersController`). No new dependencies or migrations are required.

## Remaining risks / assumptions

- **Existing controllers**: `UsersController` extends `AuthorizedController` directly and is unaffected. If any other controller already extends `AdminController` and relies on the absence of a role constraint, it should be audited — but the search shows `AdminController` is currently unused as a base by any controller.
- **Admin-only endpoints**: actions that should be restricted to `Admin` only (e.g. role assignment) must still carry their own `[Authorize(Roles = "Admin")]` override, which is the existing pattern in `UsersController`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GL8ZGc11PdmrgU4SV1qmu4)_