### PR TITLE
Fix #46: handle null q in product search to prevent 500

### DIFF
--- a/src/VendlyServer.Api/Controllers/Catalog/ProductsController.cs
+++ b/src/VendlyServer.Api/Controllers/Catalog/ProductsController.cs
@@ -21,7 +21,7 @@ public class ProductsController(IProductService productService) : AuthorizedCont
     /// <summary>Search active products for storefront display.</summary>
     [HttpGet("search")]
     [AllowAnonymous]
-    public async Task<IResult> SearchAsync([FromQuery] string q, CancellationToken ct = default)
+    public async Task<IResult> SearchAsync([FromQuery] string? q, CancellationToken ct = default)
     {
         var result = await productService.SearchAsync(q, ct);
         return result.IsSuccess ? Results.Ok(result.Data) : result.ToProblemDetails();

--- a/src/VendlyServer.Application/Services/Products/IProductService.cs
+++ b/src/VendlyServer.Application/Services/Products/IProductService.cs
@@ -6,7 +6,7 @@ namespace VendlyServer.Application.Services.Products;
 public interface IProductService
 {
     Task<Result<List<ProductListResponse>>> GetAllAsync(CancellationToken ct = default);
-    Task<Result<List<ProductSearchResponse>>> SearchAsync(string query, CancellationToken ct = default);
+    Task<Result<List<ProductSearchResponse>>> SearchAsync(string? query, CancellationToken ct = default);
     Task<Result<ProductAdminDetailResponse>> GetByIdAsync(long id, CancellationToken ct = default);
     Task<Result<long>> CreateAsync(CreateProductRequest request, CancellationToken ct = default);
     Task<Result> UpdateAsync(long id, UpdateProductRequest request, CancellationToken ct = default);

--- a/src/VendlyServer.Application/Services/Products/ProductService.cs
+++ b/src/VendlyServer.Application/Services/Products/ProductService.cs
@@ -38,9 +38,9 @@ public class ProductService(
         return products;
     }
 
-    public async Task<Result<List<ProductSearchResponse>>> SearchAsync(string query, CancellationToken ct = default)
+    public async Task<Result<List<ProductSearchResponse>>> SearchAsync(string? query, CancellationToken ct = default)
     {
-        var normalizedQuery = query.Trim().ToLower();
+        var normalizedQuery = query?.Trim().ToLower() ?? string.Empty;
 
         if (string.IsNullOrWhiteSpace(normalizedQuery) || normalizedQuery.Length < 2)
             return new List<ProductSearchResponse>();


### PR DESCRIPTION
## Summary

Fixes #46

`GET /api/products/search` without a `?q=` query parameter caused an unhandled `NullReferenceException` in `ProductService.SearchAsync` because `query.Trim()` was called on a null value, producing a 500 response on a public, unauthenticated endpoint also used by the Telegram inline search handler.

### Root cause

`[FromQuery] string q` in ASP.NET Core binds to `null` when the parameter is absent. `ModelValidationFilter` does not reject it because there is no `[Required]` attribute. The service then calls `query.Trim()` unconditionally.

### Fix

- Changed `[FromQuery] string q` → `[FromQuery] string? q` in `ProductsController.SearchAsync`
- Changed `string query` → `string? query` in `IProductService` and `ProductService`
- Changed `query.Trim().ToLower()` → `query?.Trim().ToLower() ?? string.Empty` in `ProductService.SearchAsync`

The existing `string.IsNullOrWhiteSpace(normalizedQuery)` guard already returns an empty list for blank/short queries, so a missing `q` now gracefully returns `[]` instead of 500.

## Files changed

- `src/VendlyServer.Api/Controllers/Catalog/ProductsController.cs`
- `src/VendlyServer.Application/Services/Products/IProductService.cs`
- `src/VendlyServer.Application/Services/Products/ProductService.cs`

## Verification

`dotnet` is not available in the CI shell for this automated run. The change is a one-line null-safe operator addition with no new dependencies or logic changes beyond the null guard.

**Manual verification steps:**
- `dotnet build` should pass with no warnings on the changed files
- `GET /api/products/search` (no `?q`) → `200 []` (empty list)
- `GET /api/products/search?q=a` → `200 []` (too short, under min length)
- `GET /api/products/search?q=phone` → normal results

## Risks / assumptions

- Returning an empty list (rather than 400) for a missing `q` is consistent with how a too-short query is already handled. If a 400 response is preferred, adding `[Required]` to the controller parameter is an alternative (noted in the issue).


---
_Generated by [Claude Code](https://claude.ai/code/session_014zPsvsK9rNhCmvtE5poKpv)_