### PR TITLE
Fix #35: derive Content-Type server-side in MinIO upload

### DIFF
--- a/src/VendlyServer.Application/Services/Storages/MinioStorageService.cs
+++ b/src/VendlyServer.Application/Services/Storages/MinioStorageService.cs
@@ -13,6 +13,16 @@ public class MinioStorageService(
     private readonly MinioOptions _minio = minioOptions.Value;
     private readonly StorageOptions _storage = storageOptions.Value;
 
+    private static readonly Dictionary<string, string> MimeMap =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            [".jpg"]  = "image/jpeg",
+            [".jpeg"] = "image/jpeg",
+            [".png"]  = "image/png",
+            [".webp"] = "image/webp",
+            [".svg"]  = "image/svg+xml",
+        };
+
     public async Task<Result<string>> UploadAsync(
         IFormFile file,
         string folder,
@@ -26,6 +36,10 @@ public class MinioStorageService(
         if (file.Length > _storage.MaxFileSizeBytes)
             return StorageErrors.FileTooLarge;
 
+        var contentType = MimeMap.TryGetValue(extension, out var mime)
+            ? mime
+            : "application/octet-stream";
+
         var fileName = $"{Guid.NewGuid()}{extension}";
         var objectKey = $"{folder.Trim('/')}/{fileName}";
 
@@ -38,7 +52,7 @@ public class MinioStorageService(
                 .WithObject(objectKey)
                 .WithStreamData(stream)
                 .WithObjectSize(file.Length)
-                .WithContentType(file.ContentType ?? "application/octet-stream");
+                .WithContentType(contentType);
 
             await minioClient.PutObjectAsync(args, cancellationToken);
         }


### PR DESCRIPTION
## Summary

Fixes #35

`MinioStorageService.UploadAsync` used `file.ContentType` (from the multipart `Content-Type` header) when storing objects in MinIO. That value is fully client-controlled. An attacker with Admin/Manager access could upload a file named `exploit.jpg` with `Content-Type: text/html` and an HTML/JS body. Because both buckets are configured for anonymous public download, any browser fetching the URL would execute the payload — stored XSS from `files.vestor.uz`.

### Fix

Added a server-controlled `MimeMap` dictionary keyed on the lowercase file extension (the same extension already validated against `AllowedExtensions`). `WithContentType` now uses the map-derived value, never the client-supplied header.

```csharp
private static readonly Dictionary<string, string> MimeMap =
    new(StringComparer.OrdinalIgnoreCase)
    {
        [".jpg"]  = "image/jpeg",
        [".jpeg"] = "image/jpeg",
        [".png"]  = "image/png",
        [".webp"] = "image/webp",
        [".svg"]  = "image/svg+xml",
    };
```

The fallback is `application/octet-stream`, which browsers will not render inline.

## Files changed

- `src/VendlyServer.Application/Services/Storages/MinioStorageService.cs`

## Verification

`dotnet` is not available in the CI shell for this automated run. No new dependencies are introduced.

**Manual verification steps:**
- `dotnet build` should pass with no warnings
- Upload `.jpg` file → object stored with `Content-Type: image/jpeg` (verify via MinIO console or `mc stat`)
- Upload `.jpg` file while spoofing `Content-Type: text/html` in the form part → stored as `image/jpeg` (not `text/html`)

## Risks / assumptions

- The MimeMap covers all extensions currently in `StorageOptions.AllowedExtensions`. If new extensions are added to `AllowedExtensions` in the future, they should also be added to `MimeMap`; the fallback `application/octet-stream` is safe but may be inconvenient.
- SVG files still pass extension validation (`.svg` → `image/svg+xml`). SVG can embed JavaScript and is itself a potential XSS vector when served inline. Issue #6 also flags this. The team should consider whether to remove `.svg` from `AllowedExtensions` entirely.


---
_Generated by [Claude Code](https://claude.ai/code/session_014zPsvsK9rNhCmvtE5poKpv)_