### PR TITLE
Fix #6: correct appsettings load order so env overrides take effect

### DIFF
--- a/src/VendlyServer.Api/Dependencies.cs
+++ b/src/VendlyServer.Api/Dependencies.cs
@@ -108,11 +108,11 @@ public static class Dependencies
     {
         _ = builder.Configuration.AddJsonFile(
             Path.Join(AppContext.BaseDirectory,
-                $"appsettings.{builder.Environment.EnvironmentName}.json"),
+                $"appsettings.json"),
             optional: false);
         _ = builder.Configuration.AddJsonFile(
             Path.Join(AppContext.BaseDirectory,
-                $"appsettings.json"),
+                $"appsettings.{builder.Environment.EnvironmentName}.json"),
             optional: false);
         builder.Configuration.AddEnvironmentVariables();
 


### PR DESCRIPTION
## Summary

Fixes #6 (Finding 1 — inverted configuration loading order)

`Dependencies.ConfigureHostConfigurations` loaded `appsettings.{env}.json` first and `appsettings.json` second. In ASP.NET Core, configuration providers added later take precedence over earlier ones. This meant the base file had higher priority than the environment-specific file, so any key defined in both files always used the base value — including `Hangfire:Dashboard:Password`, which was only defined in `appsettings.json` as `changeme`. The Hangfire dashboard on the live production server was therefore always protected by the default weak password regardless of what the staging/production files contained.

> **Note:** Finding 2 (SVG XSS vector) is addressed separately in the PR for Issue #35. The SVG MIME type is now server-derived; removing `.svg` from `AllowedExtensions` is a separate product decision.

### Fix

Swapped the two `AddJsonFile` calls so `appsettings.json` is loaded first (lower priority) and `appsettings.{env}.json` is loaded second (higher priority). `AddEnvironmentVariables()` remains last (highest priority), which is correct.

**Before:**
```csharp
// appsettings.{env}.json  ← loaded first, lower priority
// appsettings.json        ← loaded second, higher priority  ← BUG
```

**After:**
```csharp
// appsettings.json        ← loaded first, lower priority (base defaults)
// appsettings.{env}.json  ← loaded second, higher priority (env overrides)
```

## Files changed

- `src/VendlyServer.Api/Dependencies.cs`

## Verification

`dotnet` is not available in the CI shell for this automated run. The change is purely an ordering swap of two identical `AddJsonFile` calls.

**Manual verification steps:**
- `dotnet build` should pass with no warnings
- In Production, a key defined in `appsettings.Production.json` should override the same key in `appsettings.json` (e.g., set a distinct `Hangfire:Dashboard:Password` in the production file and confirm it takes effect)
- Environment variables should still override both files

## Risks / assumptions

- Any key that was previously only in `appsettings.json` and relied on the inverted order (intentionally or accidentally) will now behave correctly per ASP.NET Core convention. No regression is expected.
- If `appsettings.{env}.json` is missing and `optional: false`, startup will throw as before. No change to startup failure semantics.


---
_Generated by [Claude Code](https://claude.ai/code/session_014zPsvsK9rNhCmvtE5poKpv)_