### PR TITLE
Fix #54: guard fallback SendMessageAsync in SendStartMessageAsync against network errors

### DIFF
--- a/src/VendlyServer.Application/Services/Telegram/TelegramUpdateHandler.cs
+++ b/src/VendlyServer.Application/Services/Telegram/TelegramUpdateHandler.cs
@@ -110,10 +110,20 @@ public sealed class TelegramUpdateHandler(
                 "Failed to send Telegram rich start message to chat {ChatId}. Sending fallback message.",
                 message.Chat.Id);
 
-            await botClient.SendMessageAsync(
-                message.Chat.Id,
-                BuildFallbackStartMessage(emoji),
-                cancellationToken);
+            try
+            {
+                await botClient.SendMessageAsync(
+                    message.Chat.Id,
+                    BuildFallbackStartMessage(emoji),
+                    cancellationToken);
+            }
+            catch (Exception fallbackEx) when (fallbackEx is HttpRequestException or TaskCanceledException)
+            {
+                logger.LogWarning(
+                    fallbackEx,
+                    "Failed to send Telegram fallback start message to chat {ChatId}. Giving up.",
+                    message.Chat.Id);
+            }
         }
     }
 

--- a/tests/VendlyServer.Tests/Services/TelegramUpdateHandlerTests.cs
+++ b/tests/VendlyServer.Tests/Services/TelegramUpdateHandlerTests.cs
@@ -182,10 +182,32 @@ public class TelegramUpdateHandlerTests
         Assert.Null(sentMessage.ReplyToMessageId);
     }
 
+    [Fact]
+    public async Task HandleAsync_CompletesWithoutThrowing_WhenBothRichAndFallbackStartMessageFail()
+    {
+        _botClient.ShouldFailRichMessageSend = true;
+        _botClient.ShouldFailFallbackMessageSend = true;
+
+        await _handler.HandleAsync(new TelegramUpdate
+        {
+            Message = new TelegramMessage
+            {
+                MessageId = 456,
+                Text = "/start",
+                From = new TelegramUser { Id = 123, Username = "timur_test" },
+                Chat = new TelegramChat { Id = 123, Username = "timur_test" }
+            }
+        });
+
+        Assert.Equal(2, _botClient.SendMessageAttempts);
+        Assert.Empty(_botClient.SentMessages);
+    }
+
     private sealed class FakeTelegramBotClient : ITelegramBotClient
     {
         public string? AnsweredInlineQueryId { get; private set; }
         public bool ShouldFailRichMessageSend { get; set; }
+        public bool ShouldFailFallbackMessageSend { get; set; }
         public int SendMessageAttempts { get; private set; }
         public List<Dictionary<string, object?>> AnsweredResults { get; private set; } = [];
         public List<(long ChatId, string Text, TelegramInlineKeyboardMarkup? ReplyMarkup, long? ReplyToMessageId)> SentMessages { get; } = [];
@@ -203,6 +225,8 @@ public class TelegramUpdateHandlerTests
             SendMessageAttempts++;
             if (ShouldFailRichMessageSend && replyMarkup is not null)
                 throw new HttpRequestException("Telegram rejected rich message.");
+            if (ShouldFailFallbackMessageSend && replyMarkup is null)
+                throw new HttpRequestException("Telegram rejected fallback message.");
 
             SentMessages.Add((chatId, text, replyMarkup, replyToMessageId));
             return Task.CompletedTask;


### PR DESCRIPTION
Fixes #54

## Summary

`SendStartMessageAsync` sends a rich Telegram message first, and on `HttpRequestException` or `TaskCanceledException` falls back to a simpler plain message. The fallback `SendMessageAsync` call was itself unguarded. If the fallback also threw (e.g. during a network outage or when the webhook's cancellation token fired), the exception propagated up the full call chain:

```
SendStartMessageAsync → HandleMessageAsync → HandleAsync → TelegramController.HandleWebhookAsync
```

Neither `HandleMessageAsync` nor `HandleAsync` has a catch block, so the unhandled exception caused the controller to return `500 Internal Server Error`. Telegram treats 5xx responses as delivery failures and retries the webhook delivery, potentially amplifying an already-degraded connection.

### Fix

Wrapped the fallback `SendMessageAsync` in its own `try/catch (HttpRequestException or TaskCanceledException)` guard — consistent with the pattern already used in `TrySetStartReactionAsync`:

```csharp
catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
{
    logger.LogWarning(ex, "Failed to send Telegram rich start message to chat {ChatId}. Sending fallback message.", message.Chat.Id);

    try
    {
        await botClient.SendMessageAsync(message.Chat.Id, BuildFallbackStartMessage(emoji), cancellationToken);
    }
    catch (Exception fallbackEx) when (fallbackEx is HttpRequestException or TaskCanceledException)
    {
        logger.LogWarning(fallbackEx, "Failed to send Telegram fallback start message to chat {ChatId}. Giving up.", message.Chat.Id);
    }
}
```

### New test

Added `HandleAsync_CompletesWithoutThrowing_WhenBothRichAndFallbackStartMessageFail`:
- sets both `ShouldFailRichMessageSend = true` and `ShouldFailFallbackMessageSend = true` on the fake client
- asserts `HandleAsync` completes without propagating an exception
- asserts `SendMessageAttempts == 2` and `SentMessages` is empty (both attempts failed and were swallowed)

Also added `ShouldFailFallbackMessageSend` flag to `FakeTelegramBotClient` to support this scenario.

## Files changed

- `src/VendlyServer.Application/Services/Telegram/TelegramUpdateHandler.cs` — wrap fallback send in try/catch
- `tests/VendlyServer.Tests/Services/TelegramUpdateHandlerTests.cs` — add `ShouldFailFallbackMessageSend` flag and new test case

## Verification

The .NET SDK was not available in this environment. The change is a minimal try/catch addition using the same exception filter pattern already present in the method.

**Manual verification steps:**
- `dotnet test` — all existing Telegram handler tests should pass, plus the new one
- In a network-degraded environment, a `/start` webhook with both send attempts failing should return `200 OK` from the controller (not `500`)

## Risks / assumptions

- Only `HttpRequestException` and `TaskCanceledException` are caught — consistent with the existing guard. Other exception types (e.g. `OperationCanceledException` from a hard abort) still propagate, which is intentional.
- The issue notes that `TrySendWelcomeAnimationAsync` was removed in a prior commit. The fix is self-contained and does not depend on that method.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vk5nByEDGG2nceenuwAiqg)_