### PR TITLE
Fix #57: move hardcoded Telegram bot username to TelegramBotOptions

### DIFF
--- a/src/VendlyServer.Api/appsettings.Development.json
+++ b/src/VendlyServer.Api/appsettings.Development.json
@@ -35,6 +35,7 @@
   "TelegramBot": {
     "Enabled": false,
     "Token": "8729785259:AAGZvxgnYzhylTPervZHS51iF44wboHBFdg",
+    "BotUsername": "optouzbot",
     "PublicBaseUrl": "https://stage-opto.vestor.uz",
     "MiniAppUrl": "https://vendly-client.vercel.app",
     "WebhookSecretToken": "MySecret",

--- a/src/VendlyServer.Api/appsettings.Production.json
+++ b/src/VendlyServer.Api/appsettings.Production.json
@@ -28,6 +28,7 @@
   "TelegramBot": {
     "Enabled": false,
     "Token": "8729785259:AAGZvxgnYzhylTPervZHS51iF44wboHBFdg",
+    "BotUsername": "optouzbot",
     "PublicBaseUrl": "https://api-opto.vestor.uz",
     "MiniAppUrl": "https://opto.vestor.uz",
     "WebhookSecretToken": "MySecret",

--- a/src/VendlyServer.Api/appsettings.Staging.json
+++ b/src/VendlyServer.Api/appsettings.Staging.json
@@ -28,6 +28,7 @@
   "TelegramBot": {
     "Enabled": true,
     "Token": "8729785259:AAGZvxgnYzhylTPervZHS51iF44wboHBFdg",
+    "BotUsername": "optouzbot",
     "PublicBaseUrl": "https://api-stage-opto.vestor.uz",
     "MiniAppUrl": "https://stage-opto.vestor.uz",
     "WebhookSecretToken": "MySecret",

--- a/src/VendlyServer.Application/Services/Telegram/TelegramBotOptions.cs
+++ b/src/VendlyServer.Application/Services/Telegram/TelegramBotOptions.cs
@@ -7,6 +7,7 @@ public sealed class TelegramBotOptions
 {
     public bool Enabled { get; set; }
     public string Token { get; set; } = string.Empty;
+    public string BotUsername { get; set; } = string.Empty;
     public string PublicBaseUrl { get; set; } = string.Empty;
     public string MiniAppUrl { get; set; } = string.Empty;
     public string WebhookSecretToken { get; set; } = string.Empty;

--- a/src/VendlyServer.Application/Services/Telegram/TelegramUpdateHandler.cs
+++ b/src/VendlyServer.Application/Services/Telegram/TelegramUpdateHandler.cs
@@ -94,13 +94,15 @@ public sealed class TelegramUpdateHandler(
         if (message.Chat is null)
             return;
 
+        var botUsername = _options.BotUsername;
+
         try
         {
             await botClient.SendMessageAsync(
                 message.Chat.Id,
-                BuildStartMessage(emoji),
+                BuildStartMessage(emoji, botUsername),
                 cancellationToken,
-                BuildSearchKeyboard(message),
+                BuildSearchKeyboard(message, botUsername),
                 message.MessageId > 0 ? message.MessageId : null);
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
@@ -112,7 +114,7 @@ public sealed class TelegramUpdateHandler(
 
             await botClient.SendMessageAsync(
                 message.Chat.Id,
-                BuildFallbackStartMessage(emoji),
+                BuildFallbackStartMessage(emoji, botUsername),
                 cancellationToken);
         }
     }
@@ -136,7 +138,7 @@ public sealed class TelegramUpdateHandler(
         }
     }
 
-    private static string BuildStartMessage(string emoji)
+    private static string BuildStartMessage(string emoji, string botUsername)
     {
         return $"""
                 {emoji} <b>Assalomu alaykum!</b>
@@ -145,22 +147,22 @@ public sealed class TelegramUpdateHandler(
 
                 Mahsulotlarni tez qidirishingiz mumkin.
 
-                Inline qidiruv: istalgan chatda <code>@optouzbot</code> va mahsulot nomini yozing.
+                Inline qidiruv: istalgan chatda <code>@{botUsername}</code> va mahsulot nomini yozing.
                 """;
     }
 
-    private static string BuildFallbackStartMessage(string emoji)
+    private static string BuildFallbackStartMessage(string emoji, string botUsername)
     {
         return $"""
                 {emoji} Assalomu alaykum!
 
                 Bu Opto'ning rasmiy boti.
 
-                Mahsulot qidirish uchun istalgan chatda @optouzbot va mahsulot nomini yozing.
+                Mahsulot qidirish uchun istalgan chatda @{botUsername} va mahsulot nomini yozing.
                 """;
     }
 
-    private static TelegramInlineKeyboardMarkup BuildSearchKeyboard(TelegramMessage message)
+    private static TelegramInlineKeyboardMarkup BuildSearchKeyboard(TelegramMessage message, string botUsername)
     {
         return new TelegramInlineKeyboardMarkup
         {
@@ -170,17 +172,17 @@ public sealed class TelegramUpdateHandler(
                     new TelegramInlineKeyboardButton
                     {
                         Text = "🔎 Mahsulot qidirish",
-                        Url = BuildSearchDeepLink(message)
+                        Url = BuildSearchDeepLink(message, botUsername)
                     }
                 ]
             ]
         };
     }
 
-    private static string BuildSearchDeepLink(TelegramMessage message)
+    private static string BuildSearchDeepLink(TelegramMessage message, string botUsername)
     {
         var username = (message.From?.Username ?? message.Chat?.Username)?.Trim().TrimStart('@');
-        var encodedText = Uri.EscapeDataString("@optouzbot ab");
+        var encodedText = Uri.EscapeDataString($"@{botUsername} ab");
 
         if (!string.IsNullOrWhiteSpace(username))
         {


### PR DESCRIPTION
Fixes #57

## Summary

`@optouzbot` was hardcoded as a string literal in three places inside `TelegramUpdateHandler`:

- `BuildStartMessage` — rendered in the rich HTML start message
- `BuildFallbackStartMessage` — rendered in the plain-text fallback message
- `BuildSearchDeepLink` — embedded in the inline search deep-link URL

`TelegramBotOptions` already holds all other environment-specific bot identity fields (`Token`, `PublicBaseUrl`, `MiniAppUrl`, `WebhookSecretToken`). The bot username was the only piece missing, meaning any future environment that uses a different bot username (e.g. `@optouzbot_dev`) would silently generate broken deep links and wrong in-message text with no compile-time or startup warning.

### Fix

Added `BotUsername` to `TelegramBotOptions` and populated it in all three appsettings files. In `TelegramUpdateHandler.SendStartMessageAsync`, `_options.BotUsername` is read once into a local variable and passed as a parameter to the four affected static methods (`BuildStartMessage`, `BuildFallbackStartMessage`, `BuildSearchKeyboard`, `BuildSearchDeepLink`). No logic was changed — only the hardcoded literal is replaced with the config-driven value.

## Files changed

- `src/VendlyServer.Application/Services/Telegram/TelegramBotOptions.cs` — add `BotUsername` property
- `src/VendlyServer.Api/appsettings.Production.json` — add `"BotUsername": "optouzbot"`
- `src/VendlyServer.Api/appsettings.Staging.json` — add `"BotUsername": "optouzbot"`
- `src/VendlyServer.Api/appsettings.Development.json` — add `"BotUsername": "optouzbot"`
- `src/VendlyServer.Application/Services/Telegram/TelegramUpdateHandler.cs` — thread `botUsername` through four static methods

## Verification

`dotnet` is not available in this CI shell. The change is purely additive: a new config property and parameter threading with no control-flow changes.

**Manual verification steps:**
- `dotnet build` — should pass with no warnings
- Send `/start` to the bot; the message and keyboard deep-link should include the configured `BotUsername`, not a hardcoded string
- Set `BotUsername` to a different value in a local appsettings override; confirm the message reflects the override

## Risks / assumptions

- Both staging and production currently use the same bot (`optouzbot`), so the initial `BotUsername` value is identical in all three files. The value should be updated per environment once the bots are separated.
- If `BotUsername` is left empty in config, `@` will appear alone in the message text. A startup validation guard (e.g. `[Required]` annotation or a `ValidateOnStart` check) could be added as a follow-up if desired.

---
_Generated by [Claude Code](https://claude.ai/code/session_011XBqQ7pJHkLWGi5JUchfnV)_