### PR TITLE
Fix #48: wrap RegenerateVariantsAsync in an explicit DB transaction

### DIFF
--- a/src/VendlyServer.Application/Services/Products/ProductService.cs
+++ b/src/VendlyServer.Application/Services/Products/ProductService.cs
@@ -288,6 +288,8 @@ public class ProductService(
         var existingVariants = product.Variants.ToList();
         var usedVariantIds = new HashSet<long>();
 
+        await using var tx = await dbContext.Database.BeginTransactionAsync(ct);
+
         foreach (var combo in combinations)
         {
             var comboIds = combo.Select(o => o.Id).OrderBy(x => x).ToList();
@@ -333,6 +335,7 @@ public class ProductService(
             v.IsDeleted = true;
 
         await dbContext.SaveChangesAsync(ct);
+        await tx.CommitAsync(ct);
         return Result.Success();
     }
 


### PR DESCRIPTION
Fixes #48

## Summary

`RegenerateVariantsAsync` called `SaveChangesAsync` inside the variant-combination loop with no surrounding transaction. Each new `ProductVariant` row was flushed individually so that EF could obtain the auto-generated `Id` for the subsequent `VariantOptionValues` inserts. Without a transaction boundary, a database error on loop iteration N leaves the product with some new variants persisted and the rest missing — an inconsistent state that cannot be corrected automatically.

### Fix

Added `BeginTransactionAsync` before the loop and `CommitAsync` after the final `SaveChangesAsync`. The `await using` declaration guarantees an automatic rollback if `CommitAsync` is never reached (e.g. a `DbUpdateException` is thrown mid-loop).

The per-iteration `SaveChangesAsync` (needed to get the DB-assigned `ProductVariant.Id`) is preserved — this is the minimum required to correlate `VariantOptionValues` rows. All those intermediate saves now happen inside a single atomic transaction.

```csharp
await using var tx = await dbContext.Database.BeginTransactionAsync(ct);

foreach (var combo in combinations)
{
    // ... existing logic unchanged ...
    dbContext.ProductVariants.Add(newVariant);
    await dbContext.SaveChangesAsync(ct);   // still needed for DB-assigned Id

    foreach (var opt in combo)
        dbContext.VariantOptionValues.Add(new VariantOptionValue { ... });
}

foreach (var v in existingVariants.Where(v => !usedVariantIds.Contains(v.Id)))
    v.IsDeleted = true;

await dbContext.SaveChangesAsync(ct);
await tx.CommitAsync(ct);
```

## Files changed

- `src/VendlyServer.Application/Services/Products/ProductService.cs` — add `BeginTransactionAsync` before the loop and `CommitAsync` after the final save

## Verification

`dotnet` is not available in this CI shell. The change is additive: two lines inserted around existing logic with no control-flow modifications. `IDbContextTransaction` is part of `Microsoft.EntityFrameworkCore` which is already a dependency.

**Manual verification steps:**
- `dotnet build` — should pass with no warnings
- `dotnet test` — all existing product service tests should pass
- Trigger regeneration on a product with multiple variant types; verify all combinations are created or that none are created if a simulated DB error is injected mid-loop

## Risks / assumptions

- The per-iteration `SaveChangesAsync` is retained because `VariantOptionValues` foreign-keys require the DB-assigned `ProductVariant.Id`. A HiLo / sequence key strategy would allow removing intermediate flushes entirely, but that is a separate schema-level change.
- Existing sessions that hold a stale EF change-tracker state could theoretically conflict with the new transaction boundary, but `RegenerateVariantsAsync` is a standalone operation with its own fresh `dbContext` scope per request.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nyr1uaDpG3CxkUG4TrXraN)_