### PR TITLE
Fix #63: Add role-based authorization to AdminController base class

### DIFF
--- a/src/VendlyServer.Api/Controllers/Common/AdminController.cs
+++ b/src/VendlyServer.Api/Controllers/Common/AdminController.cs
@@ -1,5 +1,8 @@
+using Microsoft.AspNetCore.Authorization;
+
 namespace VendlyServer.Api.Controllers.Common;
 
+[Authorize(Roles = "Admin,Manager")]
 public abstract class AdminController : AuthorizedController
 {
 }


### PR DESCRIPTION
## Summary

Fixes #63
Also resolves #38

`AdminController` inherited from `AuthorizedController` which only required a valid JWT (`[Authorize]`), with no role restriction. This meant any authenticated customer could call `GET /api/admin/sync-logs`, `GET /api/admin/sync-logs/{id}` (exposing raw Smartup API response bodies), and `POST /api/admin/sync-logs/trigger` (enqueuing unlimited background sync jobs).

The fix adds `[Authorize(Roles = "Admin,Manager")]` directly to `AdminController` so all current and future subclasses inherit a safe role baseline by default. Individual actions that need stricter access (e.g., `Admin` only) can still override with their own attribute.

## Files Changed

- `src/VendlyServer.Api/Controllers/Common/AdminController.cs` — added `[Authorize(Roles = "Admin,Manager")]` and required `using` statement

## Verification

The change is a single attribute addition consistent with the existing role-authorization pattern used across `UsersController`. `dotnet` SDK is not available in this environment; build verification could not be run locally — CI should confirm compilation.

## Risks / Assumptions

- `UsersController` inherits from `AuthorizedController` directly (not `AdminController`), so its existing per-action role attributes are unaffected.
- `SyncLogsController` is the only current `AdminController` subclass without per-action roles; it will now correctly require Admin or Manager.
- Future admin controllers that extend `AdminController` will automatically require Admin or Manager without any additional attributes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVfEXogsZ4ViyuJCqepqZT)_