### PR TITLE
Fix #46: Guard against null query in ProductService.SearchAsync

### DIFF
--- a/src/VendlyServer.Api/Controllers/Catalog/ProductsController.cs
+++ b/src/VendlyServer.Api/Controllers/Catalog/ProductsController.cs
@@ -30,7 +30,7 @@ public class ProductsController(IProductService productService) : AuthorizedCont
     /// <summary>Search active products for storefront display.</summary>
     [HttpGet("search")]
     [AllowAnonymous]
-    public async Task<IResult> SearchAsync([FromQuery] string q, CancellationToken ct = default)
+    public async Task<IResult> SearchAsync([FromQuery] string? q, CancellationToken ct = default)
     {
         var result = await productService.SearchAsync(q, ct);
         return result.IsSuccess ? Results.Ok(result.Data) : result.ToProblemDetails();

--- a/src/VendlyServer.Application/Services/Products/IProductService.cs
+++ b/src/VendlyServer.Application/Services/Products/IProductService.cs
@@ -7,7 +7,7 @@ public interface IProductService
 {
     Task<PagedList<ProductCardResponse>> GetAllAsync(ProductFilterRequest request, CancellationToken ct = default);
     Task<Result<List<ProductListResponse>>> GetAllAdminAsync(CancellationToken ct = default);
-    Task<Result<List<ProductSearchResponse>>> SearchAsync(string query, CancellationToken ct = default);
+    Task<Result<List<ProductSearchResponse>>> SearchAsync(string? query, CancellationToken ct = default);
     Task<Result<ProductAdminDetailResponse>> GetByIdAsync(long id, CancellationToken ct = default);
     Task<Result<long>> CreateAsync(CreateProductRequest request, CancellationToken ct = default);
     Task<Result> UpdateAsync(long id, UpdateProductRequest request, CancellationToken ct = default);

--- a/src/VendlyServer.Application/Services/Products/ProductService.cs
+++ b/src/VendlyServer.Application/Services/Products/ProductService.cs
@@ -79,9 +79,9 @@ public class ProductService(
         return products;
     }
 
-    public async Task<Result<List<ProductSearchResponse>>> SearchAsync(string query, CancellationToken ct = default)
+    public async Task<Result<List<ProductSearchResponse>>> SearchAsync(string? query, CancellationToken ct = default)
     {
-        var normalizedQuery = query.Trim().ToLower();
+        var normalizedQuery = query?.Trim().ToLower() ?? string.Empty;
 
         if (string.IsNullOrWhiteSpace(normalizedQuery) || normalizedQuery.Length < 2)
             return new List<ProductSearchResponse>();


### PR DESCRIPTION
## Summary

Fixes #46

`GET /api/products/search` without the `?q=` parameter returned 500 because ASP.NET Core bound the missing parameter as `null`, and `ProductService.SearchAsync` called `query.Trim().ToLower()` unconditionally, throwing a `NullReferenceException`.

The fix makes the parameter nullable (`string?`) throughout the call chain and replaces the unconditional `.Trim()` with a null-safe expression. A missing or null query is treated as an empty string and returns an empty list with HTTP 200, consistent with the existing short-query guard (`Length < 2`).

## Files Changed

- `src/VendlyServer.Application/Services/Products/IProductService.cs` — changed `string query` to `string? query`
- `src/VendlyServer.Application/Services/Products/ProductService.cs` — changed signature to `string?` and replaced `query.Trim().ToLower()` with `query?.Trim().ToLower() ?? string.Empty`
- `src/VendlyServer.Api/Controllers/Catalog/ProductsController.cs` — changed `[FromQuery] string q` to `[FromQuery] string? q`

## Verification

- `dotnet` SDK not available in this environment; build could not be run locally — CI should confirm.
- The endpoint is public (`[AllowAnonymous]`) and used by the Telegram inline search handler, making this a regression risk on every search.

## Remaining Risks / Assumptions

- The empty-string early return (`Length < 2`) already existed; null is now treated identically, returning an empty list without hitting the database.
- No test currently covers `GET /api/products/search` with no `?q=`; a test case asserting 200 + empty list (not 500) would prevent regression.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVfEXogsZ4ViyuJCqepqZT)_