### PR TITLE
Fix #54: Guard fallback send in SendStartMessageAsync against exceptions

### DIFF
--- a/src/VendlyServer.Application/Services/Telegram/TelegramUpdateHandler.cs
+++ b/src/VendlyServer.Application/Services/Telegram/TelegramUpdateHandler.cs
@@ -110,10 +110,20 @@ public sealed class TelegramUpdateHandler(
                 "Failed to send Telegram rich start message to chat {ChatId}. Sending fallback message.",
                 message.Chat.Id);
 
-            await botClient.SendMessageAsync(
-                message.Chat.Id,
-                BuildFallbackStartMessage(emoji),
-                cancellationToken);
+            try
+            {
+                await botClient.SendMessageAsync(
+                    message.Chat.Id,
+                    BuildFallbackStartMessage(emoji),
+                    cancellationToken);
+            }
+            catch (Exception fallbackEx) when (fallbackEx is HttpRequestException or TaskCanceledException)
+            {
+                logger.LogWarning(
+                    fallbackEx,
+                    "Failed to send Telegram fallback start message to chat {ChatId}. Giving up.",
+                    message.Chat.Id);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #54

The fallback `SendMessageAsync` call inside the `catch` block of `SendStartMessageAsync` was not wrapped in its own `try/catch`. If the fallback threw (`HttpRequestException` or `TaskCanceledException` — e.g., during a network outage or Telegram API downtime), the exception propagated up through `HandleMessageAsync → HandleAsync → TelegramController.WebhookAsync`, producing a 500 response. Telegram treats 5xx as a delivery failure and retries the webhook, potentially triggering a cascade.

The fix wraps the fallback call in the same exception filter pattern used by `TrySetStartReactionAsync`, so the handler always completes without surfacing Telegram API errors to the webhook controller.

## Files Changed

- `src/VendlyServer.Application/Services/Telegram/TelegramUpdateHandler.cs` — added `try/catch (HttpRequestException or TaskCanceledException)` around the fallback `SendMessageAsync` in `SendStartMessageAsync`

## Verification

`dotnet` SDK not available; CI should confirm. The change is additive (wrapping existing code) with no behaviour change on the happy path.

## Remaining Risks / Assumptions

- The existing test `HandleAsync_SendsFallbackStartMessage_WhenRichStartMessageFails` exercises the happy fallback path. A new test where both the rich send and the fallback send throw would confirm the handler completes without propagating an exception — that test is not added here but is recommended as follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVfEXogsZ4ViyuJCqepqZT)_