### PR TITLE
Fix #47: Use timing-safe comparison for Telegram webhook secret token

### DIFF
--- a/src/VendlyServer.Api/Controllers/Public/TelegramController.cs
+++ b/src/VendlyServer.Api/Controllers/Public/TelegramController.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Microsoft.AspNetCore.Authorization;
@@ -34,6 +36,8 @@ public sealed class TelegramController(
             return false;
 
         return Request.Headers.TryGetValue(SecretTokenHeaderName, out var actualSecretToken) &&
-               string.Equals(actualSecretToken.ToString(), _options.WebhookSecretToken, StringComparison.Ordinal);
+               CryptographicOperations.FixedTimeEquals(
+                   Encoding.UTF8.GetBytes(actualSecretToken.ToString()),
+                   Encoding.UTF8.GetBytes(_options.WebhookSecretToken));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #47 (timing-safe comparison finding only; the `"MySecret"` placeholder and shared credentials are deployment/secrets concerns outside the scope of an automated code fix).

`IsValidSecretToken` in `TelegramController` used `string.Equals` to compare the incoming webhook secret header against the configured value. `string.Equals` short-circuits on the first mismatched byte, exposing a timing side-channel: an attacker who can send many requests and measure response latency can recover the secret token one byte at a time. This is especially relevant if the token value is weak (as noted in the issue).

The fix replaces `string.Equals` with `CryptographicOperations.FixedTimeEquals`, which runs in constant time regardless of where the bytes differ. This is the same pattern already used correctly in `HangfireAuthorizationFilter` in this codebase.

## Files Changed

- `src/VendlyServer.Api/Controllers/Public/TelegramController.cs` — added `System.Security.Cryptography` and `System.Text` usings; replaced `string.Equals(...)` with `CryptographicOperations.FixedTimeEquals(Encoding.UTF8.GetBytes(...), Encoding.UTF8.GetBytes(...))` in `IsValidSecretToken`

## Verification

`dotnet` SDK not available; CI should confirm. The logic change is semantically equivalent for equal strings and only differs in timing behaviour for mismatched strings.

## Remaining Risks / Assumptions

- The other two findings in issue #47 (`"MySecret"` placeholder token and shared credentials across environments) require secrets rotation and are not addressed here — those are deployment-level changes.
- `FixedTimeEquals` requires both byte arrays to be the same length to return `true`; for different-length secrets the comparison correctly returns `false` (constant-time for same-length comparisons, early false for different lengths — acceptable for this use case).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVfEXogsZ4ViyuJCqepqZT)_