### PR TITLE
Fix #35: Derive MinIO content-type server-side; remove SVG from allowed uploads

### DIFF
--- a/src/VendlyServer.Application/Services/Storages/MinioStorageService.cs
+++ b/src/VendlyServer.Application/Services/Storages/MinioStorageService.cs
@@ -10,6 +10,14 @@ public class MinioStorageService(
     IOptions<MinioOptions> minioOptions,
     IOptions<StorageOptions> storageOptions) : IStorageService
 {
+    private static readonly Dictionary<string, string> MimeMap = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [".jpg"]  = "image/jpeg",
+        [".jpeg"] = "image/jpeg",
+        [".png"]  = "image/png",
+        [".webp"] = "image/webp",
+    };
+
     private readonly MinioOptions _minio = minioOptions.Value;
     private readonly StorageOptions _storage = storageOptions.Value;
 
@@ -26,6 +34,8 @@ public class MinioStorageService(
         if (file.Length > _storage.MaxFileSizeBytes)
             return StorageErrors.FileTooLarge;
 
+        var contentType = MimeMap.TryGetValue(extension, out var mime) ? mime : "application/octet-stream";
+
         var fileName = $"{Guid.NewGuid()}{extension}";
         var objectKey = $"{folder.Trim('/')}/{fileName}";
 
@@ -38,7 +48,7 @@ public class MinioStorageService(
                 .WithObject(objectKey)
                 .WithStreamData(stream)
                 .WithObjectSize(file.Length)
-                .WithContentType(file.ContentType ?? "application/octet-stream");
+                .WithContentType(contentType);
 
             await minioClient.PutObjectAsync(args, cancellationToken);
         }

--- a/src/VendlyServer.Application/Services/Storages/StorageOptions.cs
+++ b/src/VendlyServer.Application/Services/Storages/StorageOptions.cs
@@ -5,5 +5,5 @@ public class StorageOptions
     public string BasePath { get; set; } = "wwwroot/uploads";
     public string BaseUrl { get; set; } = "/uploads";
     public long MaxFileSizeBytes { get; set; } = 5_242_880;
-    public string[] AllowedExtensions { get; set; } = [".jpg", ".jpeg", ".png", ".webp", ".svg"];
+    public string[] AllowedExtensions { get; set; } = [".jpg", ".jpeg", ".png", ".webp"];
 }


### PR DESCRIPTION
## Summary

Fixes #35
Also resolves #6 (SVG stored XSS finding)

Two related storage security fixes in one commit:

**Fix 1 — Server-derived MIME type (issue #35)**

`MinioStorageService.UploadAsync` was passing `file.ContentType` directly to MinIO as the stored object's `Content-Type`. `IFormFile.ContentType` comes from the `Content-Type` header of the multipart form-data part and is entirely client-controlled. An attacker with Admin or Manager access could upload a file named `exploit.jpg` with `Content-Type: text/html` in the multipart header; MinIO would store and serve the object with `Content-Type: text/html`. Combined with the buckets' anonymous-download policy (issue #31), any browser fetching the URL would execute the HTML payload in the `files.vestor.uz` origin — stored XSS.

The fix introduces a `MimeMap` dictionary in `MinioStorageService` that maps the (already validated) file extension to a known-safe MIME type. Only that server-derived value is passed to MinIO; the client-supplied `ContentType` header is ignored for storage purposes.

**Fix 2 — Remove SVG from allowed extensions (issue #6)**

`.svg` was in `StorageOptions.AllowedExtensions`. SVG is XML-based and supports embedded `<script>` tags and event-handler attributes. Even with a correctly derived `image/svg+xml` MIME type, browsers will execute JavaScript embedded in an SVG when it is fetched directly. Removing `.svg` from the allowlist prevents SVG uploads entirely.

## Files Changed

- `src/VendlyServer.Application/Services/Storages/MinioStorageService.cs` — added `MimeMap` static dictionary; replaced `file.ContentType` with `MimeMap.TryGetValue(extension, ...)` for the `WithContentType` call
- `src/VendlyServer.Application/Services/Storages/StorageOptions.cs` — removed `.svg` from default `AllowedExtensions`

## Verification

`dotnet` SDK not available; CI should confirm. The MimeMap keys exactly match the remaining `AllowedExtensions` defaults, so the fallback `"application/octet-stream"` branch will only be hit if the defaults are overridden in configuration to include new extensions not yet in the map.

## Remaining Risks / Assumptions

- If `AllowedExtensions` is extended via configuration to include new types, those types will fall back to `application/octet-stream` until their entry is added to `MimeMap`. This is safer than trusting the client header.
- The fix addresses the MIME confusion vector; the broader anonymous-download bucket access policy (issue #31) is a separate infrastructure concern.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVfEXogsZ4ViyuJCqepqZT)_