### PR TITLE
Fix #64: Create new variant in sync when all existing variants are soft-deleted

### DIFF
--- a/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
+++ b/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
@@ -271,6 +271,17 @@ public class SmartupSyncService(
                     variant.Images = images;
                     variant.IsActive = true;
                 }
+                else
+                {
+                    dbContext.ProductVariants.Add(new ProductVariant
+                    {
+                        Product = product,
+                        Price = price,
+                        Quantity = quantity,
+                        Images = images,
+                        IsActive = true
+                    });
+                }
 
                 updated++;
             }


### PR DESCRIPTION
## Summary

Fixes #64 (silent variant skip finding; the cart race-condition finding in the same issue requires a unique DB constraint + migration and is out of scope for this automated fix).

In `SmartupSyncService.UpsertProductsAsync`, when an existing synced product was found but all its variants had been soft-deleted (e.g., manually removed via the admin panel), the sync updated the product's `Name`, `Description`, `CategoryId`, and `IsActive` but silently skipped updating `Price`, `Quantity`, and `Images`. The product remained active on the storefront with stale pricing and stock data from the previous sync cycle — and the `updated++` counter still incremented, making the skip invisible in sync logs.

The fix adds an `else` branch: when no non-deleted variant exists for a matched product, a new `ProductVariant` is created from the current sync data, mirroring the create-path behaviour used for brand-new products.

## Files Changed

- `src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs` — added `else` branch after the `if (variant is not null)` block in `UpsertProductsAsync` to create a new `ProductVariant` when none exists

## Verification

`dotnet` SDK not available; CI should confirm. The change is additive — the `if` path is unchanged; only the missing `else` is filled in.

## Remaining Risks / Assumptions

- The cart race-condition (duplicate carts, `SingleOrDefaultAsync` throwing `InvalidOperationException`) from the same issue requires a unique index on `Cart.UserId` and an EF Core migration, which are not included here.
- The new variant created in the `else` branch has no `Name` set (consistent with how variants are created on the new-product path in this sync service).
- `updated++` continues to increment when the `else` branch fires, which is correct — the product record was updated even if a new variant had to be created.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVfEXogsZ4ViyuJCqepqZT)_