### PR TITLE
Fix #76: preserve client-supplied ordering in BulkSyncAsync

### DIFF
--- a/src/VendlyServer.Application/Services/RecentlyViewed/RecentlyViewedService.cs
+++ b/src/VendlyServer.Application/Services/RecentlyViewed/RecentlyViewedService.cs
@@ -65,8 +65,16 @@ public class RecentlyViewedService(AppDbContext dbContext) : IRecentlyViewedServ
 
         if (validProductIds.Count == 0) return Result.Success();
 
+        // Re-order validated IDs to match the client-supplied sequence so that staggered
+        // ViewedAt timestamps reflect the client's intended "oldest first → newest last" order,
+        // not the database's natural primary-key ordering returned by ToListAsync.
+        var validSet = new HashSet<long>(validProductIds);
+        var orderedValidIds = request.ProductIds
+            .Where(id => validSet.Contains(id))
+            .ToList();
+
         var existing = await dbContext.RecentlyViewedProducts
-            .Where(r => r.UserId == userId && validProductIds.Contains(r.ProductId))
+            .Where(r => r.UserId == userId && orderedValidIds.Contains(r.ProductId))
             .ToListAsync(cancellationToken);
 
         var now = DateTime.UtcNow;
@@ -74,9 +82,9 @@ public class RecentlyViewedService(AppDbContext dbContext) : IRecentlyViewedServ
 
         // Order received from client preserves user's view order (oldest first → newest last).
         // Stagger ViewedAt by milliseconds so ordering is preserved server-side.
-        for (var i = 0; i < validProductIds.Count; i++)
+        for (var i = 0; i < orderedValidIds.Count; i++)
         {
-            var productId = validProductIds[i];
+            var productId = orderedValidIds[i];
             var viewedAt = now.AddMilliseconds(i);
 
             if (existingMap.TryGetValue(productId, out var entry))


### PR DESCRIPTION
Fixes #76

## Summary

`BulkSyncAsync` in `RecentlyViewedService` was assigning staggered `ViewedAt` timestamps in the order returned by the database (`ToListAsync` returns IDs in primary-key ascending order), not in the client-supplied order. The client sends IDs as "oldest viewed first → newest viewed last", but after the DB validation query the loop iterated in PK order — silently inverting the recency sequence.

**Example of the bug:**
- Client sends: `[1005, 1001, 1003]` (1005 viewed earliest, 1003 most recently)
- DB query returns: `[1001, 1003, 1005]` (PK order)
- Assigned `ViewedAt`: 1001 = `now+0ms`, 1003 = `now+1ms`, 1005 = `now+2ms`
- Result: 1005 appears as the most recently viewed — opposite of intent

### Fix

After the DB validation query, the validated IDs are re-ordered to match the client-supplied sequence using a `HashSet<long>` lookup:

```csharp
var validSet = new HashSet<long>(validProductIds);
var orderedValidIds = request.ProductIds
    .Where(id => validSet.Contains(id))
    .ToList();
```

The staggered-timestamp loop then iterates `orderedValidIds` instead of `validProductIds`, preserving the client's "oldest first → newest last" intent.

## Files changed

- `src/VendlyServer.Application/Services/RecentlyViewed/RecentlyViewedService.cs`

## Verification

`dotnet` is not available in this environment. The change is purely additive — a `HashSet` lookup and LINQ re-ordering of the already-validated ID list with no control-flow or schema changes.

**Manual verification steps:**
- `dotnet build` — should pass with no warnings
- Call `BulkSync` with IDs `[1005, 1001, 1003]`; verify the resulting `ViewedAt` values assign the largest timestamp to product 1003 (last in the client list) and the smallest to 1005 (first in the client list)

## Risks / assumptions

- Duplicate IDs in `request.ProductIds` will result in the last occurrence's timestamp being applied (the `existingMap` update path overwrites). This is pre-existing behaviour; the issue notes this as a follow-up to consider at the validator level.

https://claude.ai/code/session_01Lia2fWXio1tc9o8kyWDAqD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lia2fWXio1tc9o8kyWDAqD)_