### PR TITLE
Fix #78: AddressService.UpdateAsync silently ignores IsDefault: false

### DIFF
--- a/src/VendlyServer.Application/Services/Addresses/AddressService.cs
+++ b/src/VendlyServer.Application/Services/Addresses/AddressService.cs
@@ -146,7 +146,7 @@ public class AddressService(AppDbContext dbContext) : IAddressService
         address.House = request.House;
         address.Extra = request.Extra;
         address.BtsCityCode = request.BtsCityCode;
-        address.IsDefault = request.IsDefault || address.IsDefault;
+        address.IsDefault = request.IsDefault;
 
         await dbContext.SaveChangesAsync(cancellationToken);
 


### PR DESCRIPTION
## Summary

Fixes #78

`AddressService.UpdateAsync` used `||` when assigning `IsDefault`, which meant sending `IsDefault: false` for a currently-default address had no effect — the address would silently remain as default. The existing guard block (lines 132–140) already handles clearing other defaults when promoting an address, so the only change needed is to replace the broken expression with a direct assignment.

**Before:**
```csharp
address.IsDefault = request.IsDefault || address.IsDefault;
```

**After:**
```csharp
address.IsDefault = request.IsDefault;
```

## Files Changed

- `src/VendlyServer.Application/Services/Addresses/AddressService.cs` — line 149

## Verification

`dotnet` is not installed in the automated execution environment, so a local build could not be run. The change is a one-line substitution between two expressions of the same `bool` type — no compile risk. The surrounding logic (clear-other-defaults guard block) is untouched.

**Manual verification steps:**
1. Create an address and mark it as default.
2. `PUT /api/addresses/{id}` with `{ "isDefault": false }`.
3. Confirm the response returns `isDefault: false` and the address is no longer default.

## Remaining Notes

The issue also asks the team to decide whether a user can have zero default addresses. This PR does not enforce a "must have one default" constraint — it simply makes the field writable in both directions, consistent with what the API surface implies.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JK1trcSuPJJFLMxa8xHcXA)_