### PR TITLE
Fix #74: Set explicit 30s timeout on Smartup HTTP client

### DIFF
--- a/src/VendlyServer.Infrastructure/Dependencies.cs
+++ b/src/VendlyServer.Infrastructure/Dependencies.cs
@@ -67,7 +67,10 @@ public static class Dependencies
     private static IServiceCollection ConfigureSmartup(this IServiceCollection services)
     {
         services.ConfigureOptions<SmartupOptionsSetup>();
-        services.AddHttpClient("Smartup");
+        services.AddHttpClient("Smartup", client =>
+        {
+            client.Timeout = TimeSpan.FromSeconds(30);
+        });
         services.AddSingleton<ISmartupBroker, SmartupBroker>();
 
         return services;


### PR DESCRIPTION
## Summary

Fixes #74

The Smartup named `HttpClient` was registered without an explicit timeout, falling back to the 100-second `HttpClient` default. During the nightly catalog sync (`SmartupCatalogSyncJob`), each `PostAsync` call can block a Hangfire worker thread for up to 100 seconds if the Smartup API is slow or unresponsive. With `CancellationToken.None` passed at job enqueue time, there is no early-exit path. A single hung multi-page sync could block the worker pool for thousands of seconds, starving all other background jobs.

This PR sets a 30-second explicit timeout on the client, which is a safe upper bound for a synchronous external API call.

**Before:**
```csharp
services.AddHttpClient("Smartup");
```

**After:**
```csharp
services.AddHttpClient("Smartup", client =>
{
    client.Timeout = TimeSpan.FromSeconds(30);
});
```

## Files Changed

- `src/VendlyServer.Infrastructure/Dependencies.cs` — `ConfigureSmartup()` method

## Verification

`dotnet` is not installed in the automated execution environment, so a local build could not be run. The change adds a single `TimeSpan` property assignment inside the existing `AddHttpClient` factory delegate — no API surface change, no new dependencies.

**Manual verification steps:**
1. Deploy to staging and trigger a Smartup catalog sync.
2. Simulate a slow Smartup API (e.g., via a mock endpoint with a 35s delay) and confirm the job fails with a `TaskCanceledException` after ~30 seconds rather than blocking indefinitely.

## Remaining Notes

The issue also identifies `CancellationToken.None` being passed at Hangfire job enqueue time (`SmartupCatalogSyncJob.cs`), which prevents job cancellation on server shutdown. That is a separate change and can be addressed in a follow-up: Hangfire supplies a cancellation token automatically when the job parameter is typed as `IJobCancellationToken` or `CancellationToken` — no `.None` override is needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JK1trcSuPJJFLMxa8xHcXA)_