### PR TITLE
Fix #75: cap SmartupSync pagination loop to prevent runaway API requests

### DIFF
--- a/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
+++ b/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
@@ -172,6 +172,8 @@ public class SmartupSyncService(
         var totalErrors = 0;
         var details = new List<object>();
 
+        const int MaxPages = 500;
+
         foreach (var cat in categories)
         {
             if (!categoryIdMap.TryGetValue(cat.ProductTypeId, out var categoryId))
@@ -198,7 +200,18 @@ public class SmartupSyncService(
                 }
 
                 var envelope = call.Result.Data!;
-                pageCount = envelope.GetPageCount();
+
+                if (page == 1)
+                {
+                    pageCount = envelope.GetPageCount();
+                    if (pageCount > MaxPages)
+                    {
+                        logger.LogWarning(
+                            "Smartup Sync [{LogId}]: category {TypeId} reports {Pages} pages — capping at {Max}",
+                            logId, cat.ProductTypeId, pageCount, MaxPages);
+                        pageCount = MaxPages;
+                    }
+                }
 
                 var (c, u) = await UpsertProductsAsync(envelope.Products, categoryId, cancellationToken);
                 catCreated += c;


### PR DESCRIPTION
## Summary

Fixes #75

`SmartupSyncService.SyncProductsAsync` refreshed `pageCount` from the external API on every loop iteration with no upper bound. A misbehaving or misconfigured Smartup API returning an abnormally large page count (or increasing it mid-loop) would cause the job to make thousands of HTTP requests and `SaveChangesAsync` calls, monopolising the Hangfire worker thread and exhausting API quota.

Two bounded changes:
- **Read `pageCount` only once** (from the first page response). Subsequent iterations keep the page count fixed, preventing a pathological API response from driving the loop upward mid-run.
- **Cap at `MaxPages = 500`** with a `LogWarning` if the API reports more. 500 pages is a conservative ceiling well above any realistic catalog size; if the limit needs tuning it is a single constant.

## Files changed

- `src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs` — `SyncProductsAsync` pagination loop

## Verification

Build verification could not be run (dotnet CLI not available in this environment). The change touches only the loop control logic inside `SyncProductsAsync`; all other sync behaviour (category sync, upsert, logging) is unchanged.

## Risks / assumptions

- `MaxPages = 500` is a hard-coded constant. If the real catalog exceeds 500 pages the sync will silently truncate with a warning log. A configurable value via `SmartupOptions` would be a follow-up improvement.
- No functional change for catalogs with ≤ 500 pages (the common case).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VyzDq94VfJ23qymLQGnRcv)_