### PR TITLE
Fix #88: Replace ContinueWith with two-step await in SyncCategoriesAsync

### DIFF
--- a/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
+++ b/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
@@ -147,12 +147,13 @@ public class SmartupSyncService(
         logger.LogInformation("Smartup Sync [{LogId}]: categories — +{Created} ~{Updated}",
             logId, created, updated);
 
-        var idMap = await dbContext.Categories
+        var allCats = await dbContext.Categories
             .Where(c => !c.IsDeleted && c.Metadata != null)
-            .ToListAsync(cancellationToken)
-            .ContinueWith(t => t.Result
-                .Where(c => TryGetSourceId(c.Metadata, out _))
-                .ToDictionary(c => GetSourceId(c.Metadata)!, c => c.Id));
+            .ToListAsync(cancellationToken);
+
+        var idMap = allCats
+            .Where(c => TryGetSourceId(c.Metadata, out _))
+            .ToDictionary(c => GetSourceId(c.Metadata)!, c => c.Id);
 
         return (idMap, created, updated);
     }


### PR DESCRIPTION
Fixes #88

## Summary

- Replaced `.ContinueWith(t => t.Result ...)` chained onto `ToListAsync(cancellationToken)` with a two-step pattern: first `await ToListAsync`, then apply the in-memory LINQ projection.
- The logic is semantically identical; the only difference is cancellation behaviour: previously, if the `CancellationToken` fired during `ToListAsync`, accessing `t.Result` inside the continuation raised `AggregateException` (wrapping `OperationCanceledException`), breaking the standard .NET cancellation contract expected by Hangfire job runners, retry policies, and structured logging.

## Files Changed

- `src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs` — `SyncCategoriesAsync` method (lines 150–156)

## Verification

- .NET SDK not available in the automated run environment; change is a mechanical, non-logic-altering transformation (split one chained expression into two statements). No conditional logic, no new dependencies, no API surface change.
- Build verification should be confirmed in CI.

## Risks / Assumptions

- No logic change — the filtered dictionary is built from the same query result with the same predicates.
- The extra local variable `allCats` is a `List<Category>` already in memory; no additional DB round-trip.

https://claude.ai/code/session_01Q267jPsJfqCETa7dqWq5RG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q267jPsJfqCETa7dqWq5RG)_