### PR TITLE
Fix #89: Recreate missing variant in UpsertProductsAsync and harden cart queries

### DIFF
--- a/src/VendlyServer.Application/Services/Carts/CartService.cs
+++ b/src/VendlyServer.Application/Services/Carts/CartService.cs
@@ -75,7 +75,7 @@ public class CartService(AppDbContext dbContext) : ICartService
             .Include(c => c.Items.Where(i => !i.IsDeleted))
                 .ThenInclude(i => i.ProductVariant)
                     .ThenInclude(v => v.Product)
-            .SingleOrDefaultAsync(cancellationToken);
+            .FirstOrDefaultAsync(cancellationToken);
 
         if (cart is null) return CartErrors.ItemNotFound;
 
@@ -103,7 +103,7 @@ public class CartService(AppDbContext dbContext) : ICartService
             .Include(c => c.Items.Where(i => !i.IsDeleted))
                 .ThenInclude(i => i.ProductVariant)
                     .ThenInclude(v => v.Product)
-            .SingleOrDefaultAsync(cancellationToken);
+            .FirstOrDefaultAsync(cancellationToken);
 
         if (cart is null) return CartErrors.ItemNotFound;
 
@@ -135,7 +135,7 @@ public class CartService(AppDbContext dbContext) : ICartService
             .Include(c => c.Items.Where(i => !i.IsDeleted))
                 .ThenInclude(i => i.ProductVariant)
                     .ThenInclude(v => v.Product)
-            .SingleOrDefaultAsync(cancellationToken);
+            .FirstOrDefaultAsync(cancellationToken);
     }
 
     private static CartResponse MapToResponse(Cart cart)

--- a/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
+++ b/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
@@ -276,6 +276,20 @@ public class SmartupSyncService(
                     variant.Images = images;
                     variant.IsActive = true;
                 }
+                else
+                {
+                    dbContext.ProductVariants.Add(new ProductVariant
+                    {
+                        Product = product,
+                        Price = price,
+                        Quantity = quantity,
+                        Images = images,
+                        IsActive = true
+                    });
+                    logger.LogWarning(
+                        "Smartup Sync: product {ProductId} had no active variant; created new one",
+                        item.ProductId);
+                }
 
                 updated++;
             }


### PR DESCRIPTION
Fixes #89

## Summary

Two bounded fixes addressing the two warnings in the issue:

### 1. `SmartupSyncService.UpsertProductsAsync` — recreate missing variant

When a product already exists in the DB but all its variants were soft-deleted (e.g., by a manual edit or a partially failed prior sync), the previous code marked the product `IsActive = true` and counted it as `updated` while silently leaving price, quantity, and images unchanged. This caused customers to see active product listings with stale or missing data.

The fix adds an `else` branch: when no active variant is found, a new `ProductVariant` is added via `dbContext.ProductVariants.Add(...)` and a `LogWarning` is emitted so the condition is visible in logs.

### 2. `CartService` — harden cart lookups against duplicate-cart 500s

A TOCTOU race can produce two `Cart` rows for the same `UserId`. When that happens, `SingleOrDefaultAsync` throws `InvalidOperationException` (HTTP 500), locking the user out of all cart operations. Changing to `FirstOrDefaultAsync` in `FindCartWithItemsAsync`, `UpdateItemAsync`, and `RemoveItemAsync` prevents the exception and lets the user's session continue.

> **Note:** The root cause (no unique DB constraint on `carts.user_id where is_deleted = false`) is tracked separately and requires a migration with team review. This change is the minimum safe mitigation.

## Files Changed

- `src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs` — `UpsertProductsAsync` method: added `else` branch with variant creation and warning log
- `src/VendlyServer.Application/Services/Carts/CartService.cs` — `FindCartWithItemsAsync`, `UpdateItemAsync`, `RemoveItemAsync`: `SingleOrDefaultAsync` → `FirstOrDefaultAsync` for cart queries

## Verification

- .NET SDK not available in the automated run environment; CI build required.
- Code review: `ProductVariant` construction matches the same fields used in the `else` (new-product) branch of the same method.
- `SingleOrDefaultAsync` for the `ProductVariants` lookup in `AddItemAsync` (line 30) was intentionally left unchanged — a variant ID is a primary key lookup where duplicates are impossible.

## Remaining Risks / Assumptions

- Duplicate-cart race: `FirstOrDefaultAsync` silences the 500 but the duplicate row remains. A follow-up migration adding `CREATE UNIQUE INDEX ... WHERE is_deleted = false` on `carts.user_id` is needed to prevent the race at the DB level.
- The new variant created by the `else` branch has no `Name` or `Metadata` (same as the new-product path). If the product schema requires those fields they should be added in a follow-up.

https://claude.ai/code/session_01Q267jPsJfqCETa7dqWq5RG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q267jPsJfqCETa7dqWq5RG)_