### PR TITLE
Fix #88: ContinueWith wraps OperationCanceledException in AggregateException

### DIFF
--- a/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
+++ b/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
@@ -147,12 +147,13 @@ public class SmartupSyncService(
         logger.LogInformation("Smartup Sync [{LogId}]: categories — +{Created} ~{Updated}",
             logId, created, updated);
 
-        var idMap = await dbContext.Categories
+        var allCats = await dbContext.Categories
             .Where(c => !c.IsDeleted && c.Metadata != null)
-            .ToListAsync(cancellationToken)
-            .ContinueWith(t => t.Result
-                .Where(c => TryGetSourceId(c.Metadata, out _))
-                .ToDictionary(c => GetSourceId(c.Metadata)!, c => c.Id));
+            .ToListAsync(cancellationToken);
+
+        var idMap = allCats
+            .Where(c => TryGetSourceId(c.Metadata, out _))
+            .ToDictionary(c => GetSourceId(c.Metadata)!, c => c.Id);
 
         return (idMap, created, updated);
     }


### PR DESCRIPTION
## Summary

Fixes #88

Replaces the `.ContinueWith()` chain on `ToListAsync` in `SmartupSyncService.SyncCategoriesAsync` with a two-step await + in-memory LINQ projection. The previous pattern accessed `t.Result` on a cancelled/faulted task, which wraps `OperationCanceledException` in `AggregateException` and breaks the .NET structured-cancellation contract for the Hangfire sync job.

## Fix

**Before:**
```csharp
var idMap = await dbContext.Categories
    .Where(c => !c.IsDeleted && c.Metadata != null)
    .ToListAsync(cancellationToken)
    .ContinueWith(t => t.Result   // throws AggregateException on cancel/fault
        .Where(c => TryGetSourceId(c.Metadata, out _))
        .ToDictionary(c => GetSourceId(c.Metadata)!, c => c.Id));
```

**After:**
```csharp
var allCats = await dbContext.Categories
    .Where(c => !c.IsDeleted && c.Metadata != null)
    .ToListAsync(cancellationToken);

var idMap = allCats
    .Where(c => TryGetSourceId(c.Metadata, out _))
    .ToDictionary(c => GetSourceId(c.Metadata)!, c => c.Id);
```

The logic is identical — only the cancellation propagation is fixed.

## Files Changed

- `src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs` (lines 150–157)

## Verification

The .NET SDK was not available in the automated execution environment; the fix was verified by code inspection. The change is a direct mechanical replacement with no logic change — the EF Core query and in-memory LINQ filter/dictionary projection are unchanged; only the task continuation idiom was replaced with a standard `await` + synchronous LINQ chain.

## Risks / Assumptions

- No logic change; equivalent output in the success path.
- On cancellation the fix now correctly propagates `OperationCanceledException` to Hangfire, which can then apply its retry/abort policies as designed.
- No migration required.

---
_Generated by [Claude Code](https://claude.ai/code/session_012UeoyLqueSLQyTPPc6QRbe)_