### PR TITLE
Fix #89: Silent variant skip in sync and cart InvalidOperationException on race

### DIFF
--- a/src/VendlyServer.Application/Services/Carts/CartService.cs
+++ b/src/VendlyServer.Application/Services/Carts/CartService.cs
@@ -75,7 +75,7 @@ public class CartService(AppDbContext dbContext) : ICartService
             .Include(c => c.Items.Where(i => !i.IsDeleted))
                 .ThenInclude(i => i.ProductVariant)
                     .ThenInclude(v => v.Product)
-            .SingleOrDefaultAsync(cancellationToken);
+            .FirstOrDefaultAsync(cancellationToken);
 
         if (cart is null) return CartErrors.ItemNotFound;
 
@@ -103,7 +103,7 @@ public class CartService(AppDbContext dbContext) : ICartService
             .Include(c => c.Items.Where(i => !i.IsDeleted))
                 .ThenInclude(i => i.ProductVariant)
                     .ThenInclude(v => v.Product)
-            .SingleOrDefaultAsync(cancellationToken);
+            .FirstOrDefaultAsync(cancellationToken);
 
         if (cart is null) return CartErrors.ItemNotFound;
 
@@ -135,7 +135,7 @@ public class CartService(AppDbContext dbContext) : ICartService
             .Include(c => c.Items.Where(i => !i.IsDeleted))
                 .ThenInclude(i => i.ProductVariant)
                     .ThenInclude(v => v.Product)
-            .SingleOrDefaultAsync(cancellationToken);
+            .FirstOrDefaultAsync(cancellationToken);
     }
 
     private static CartResponse MapToResponse(Cart cart)

--- a/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
+++ b/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
@@ -271,6 +271,20 @@ public class SmartupSyncService(
                     variant.Images = images;
                     variant.IsActive = true;
                 }
+                else
+                {
+                    dbContext.ProductVariants.Add(new ProductVariant
+                    {
+                        Product = product,
+                        Price = price,
+                        Quantity = quantity,
+                        Images = images,
+                        IsActive = true
+                    });
+                    logger.LogWarning(
+                        "Smartup Sync: product {ProductId} had no active variant; created new one",
+                        item.ProductId);
+                }
 
                 updated++;
             }


### PR DESCRIPTION
## Summary

Fixes #89

Two findings from the automated review of commit `bc68a63`:

### Finding 1 — `SmartupSyncService.UpsertProductsAsync`: silent variant skip

When Smartup sends data for a product that exists in the DB but whose variants were all soft-deleted, the product was set to `IsActive = true` and counted as "updated" — but its price, quantity, and images remained stale. The product was then served to the storefront as active with potentially $0 price or zero stock, with no log entry to indicate anything was wrong.

**Fix:** Added an `else` branch that creates a new `ProductVariant` and emits a `LogWarning` so the condition is visible in sync logs.

### Finding 2 — `CartService`: `SingleOrDefaultAsync` throws on duplicate cart rows

A TOCTOU race (two concurrent requests both finding `cart is null` before either commits) can create two active `Cart` rows for the same user. Subsequent calls using `SingleOrDefaultAsync` on a query matching two rows throw `InvalidOperationException` (HTTP 500), locking the user out of all cart operations until the duplicate is manually deleted.

**Fix:** Replaced `SingleOrDefaultAsync` with `FirstOrDefaultAsync` in all three cart-by-user queries (`FindCartWithItemsAsync`, `UpdateItemAsync`, `RemoveItemAsync`). This is a defensive fallback; a DB-level unique partial index on `carts.user_id WHERE is_deleted = false` should be added in a follow-up migration to prevent the duplicate row from being created in the first place.

## Files Changed

- `src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs` — added `else` branch in `UpsertProductsAsync` (~14 lines)
- `src/VendlyServer.Application/Services/Carts/CartService.cs` — 3× `SingleOrDefaultAsync` → `FirstOrDefaultAsync`

## Verification

The .NET SDK was not available in the automated execution environment; fixes were verified by code inspection. Both changes are minimal and mechanical:
- The variant creation block mirrors the existing creation path in the `else` branch of the `existingDict.TryGetValue` check.
- `FirstOrDefaultAsync` is a direct drop-in for `SingleOrDefaultAsync` with identical query SQL; it only differs in behavior when the result set contains more than one row.

## Risks / Assumptions

- Finding 1 adds a new `ProductVariant` row when none exists for a synced product. This is consistent with the creation path for new products and will not affect products with existing active variants.
- Finding 2 (`FirstOrDefaultAsync`) does not prevent duplicate carts from being created — it only prevents a 500 error if they exist. A follow-up DB migration adding `UNIQUE (user_id) WHERE is_deleted = false` on the `carts` table is recommended to close the race fully.
- No migration is required for this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_012UeoyLqueSLQyTPPc6QRbe)_