### PR TITLE
Fix #84: Email uniqueness bypass in RegisterAsync and HTTP 500 on duplicate email login

### DIFF
--- a/src/VendlyServer.Application/Services/Auth/AuthService.cs
+++ b/src/VendlyServer.Application/Services/Auth/AuthService.cs
@@ -20,7 +20,7 @@ public class AuthService(
     {
         var user = await dbContext.Users
             .AsNoTracking()
-            .SingleOrDefaultAsync(u => (u.Phone == request.Login || u.Email == request.Login) && !u.IsDeleted, cancellationToken);
+            .FirstOrDefaultAsync(u => (u.Phone == request.Login || u.Email == request.Login) && !u.IsDeleted, cancellationToken);
 
         if (user is null || !passwordHasher.Verify(request.Password, user.PasswordHash))
             return AuthErrors.InvalidCredentials;
@@ -38,6 +38,15 @@ public class AuthService(
             .AnyAsync(u => u.Phone == request.Phone && !u.IsDeleted, cancellationToken);
 
         if (exists) return AuthErrors.UserAlreadyExists;
+
+        if (!string.IsNullOrWhiteSpace(request.Email))
+        {
+            var emailExists = await dbContext.Users
+                .AsNoTracking()
+                .AnyAsync(u => u.Email == request.Email && !u.IsDeleted, cancellationToken);
+
+            if (emailExists) return AuthErrors.UserAlreadyExists;
+        }
 
         var user = new User
         {


### PR DESCRIPTION
## Summary

Fixes #84

Two related defects in `AuthService`:

### Finding 1 — `RegisterAsync`: no email uniqueness check

`RegisterAsync` only validated phone uniqueness before inserting a user. Two accounts with different phones but the same email could be registered successfully, silently breaking email-based login for both.

**Fix:** Added an email uniqueness check (mirrors the existing phone check) immediately after the phone check. Skipped when `request.Email` is null or whitespace, as email is optional.

### Finding 2 — `LoginAsync`: `SingleOrDefaultAsync` throws HTTP 500 on duplicate email rows

`LoginAsync` queries with `(u.Phone == request.Login || u.Email == request.Login)`. If two rows share the same email, `SingleOrDefaultAsync` throws `InvalidOperationException`, surfacing as HTTP 500 to the client.

**Fix:** Replaced `SingleOrDefaultAsync` with `FirstOrDefaultAsync` as a defensive guard. This prevents the 500 for any existing duplicate rows in production while Finding 1 prevents new ones from being created.

## Files Changed

- `src/VendlyServer.Application/Services/Auth/AuthService.cs`
  - `RegisterAsync`: added email `AnyAsync` check (+9 lines)
  - `LoginAsync`: `SingleOrDefaultAsync` → `FirstOrDefaultAsync` (1 line)

## Verification

The .NET SDK was not available in the automated execution environment. The fix was verified by code inspection. The email check is structurally identical to the existing phone check; `FirstOrDefaultAsync` is a mechanical replacement with identical SQL.

## Risks / Assumptions

- Email is optional in the User entity (`string? Email`); the uniqueness check is skipped when email is absent, preserving existing behavior for phone-only registrations.
- `FirstOrDefaultAsync` in `LoginAsync` returns the first matching row on a duplicate — login still works for the affected accounts via phone. This is a stopgap; the proper fix is the DB-level unique partial index described below.
- **Follow-up recommended:** Add a partial unique index on `users.email WHERE email IS NOT NULL AND is_deleted = false` via an EF Core migration to enforce uniqueness at the persistence layer independently of application code.

---
_Generated by [Claude Code](https://claude.ai/code/session_012UeoyLqueSLQyTPPc6QRbe)_