### PR TITLE
Fix #78: IsDefault=false silently ignored in AddressService.UpdateAsync

### DIFF
--- a/src/VendlyServer.Application/Services/Addresses/AddressService.cs
+++ b/src/VendlyServer.Application/Services/Addresses/AddressService.cs
@@ -146,7 +146,7 @@ public class AddressService(AppDbContext dbContext) : IAddressService
         address.House = request.House;
         address.Extra = request.Extra;
         address.BtsCityCode = request.BtsCityCode;
-        address.IsDefault = request.IsDefault || address.IsDefault;
+        address.IsDefault = request.IsDefault;
 
         await dbContext.SaveChangesAsync(cancellationToken);
 


### PR DESCRIPTION
## Summary

Fixes #78

`AddressService.UpdateAsync` used `request.IsDefault || address.IsDefault` to update the default flag. When `address.IsDefault` was already `true`, the `||` short-circuit made the expression always `true` regardless of what the client sent — silently ignoring `IsDefault: false` and returning HTTP 200 with the flag unchanged.

The guard logic immediately above (lines 132–140) already clears other defaults when promoting an address (`request.IsDefault && !address.IsDefault`), so the direct assignment is safe and correct:

**Before:**
```csharp
address.IsDefault = request.IsDefault || address.IsDefault;
```

**After:**
```csharp
address.IsDefault = request.IsDefault;
```

## Files Changed

- `src/VendlyServer.Application/Services/Addresses/AddressService.cs` — line 149, one-character change (`|| address.IsDefault` removed)

## Verification

Fix verified by code inspection. The `if (request.IsDefault && !address.IsDefault)` block on lines 132–140 that clears other default addresses is unaffected and still runs correctly in the promotion path.

## Risks / Assumptions

- After this fix, a user can have zero default addresses (if they explicitly set `IsDefault: false` on their current default). If the product contract requires exactly one default address at all times, a validation guard rejecting `IsDefault: false` when the address is the sole default should be added. That product decision is out of scope for this fix.
- No migration required.

---
_Generated by [Claude Code](https://claude.ai/code/session_012UeoyLqueSLQyTPPc6QRbe)_