### PR TITLE
Fix #75: Cap Smartup sync pagination to prevent runaway loop

### DIFF
--- a/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
+++ b/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
@@ -159,6 +159,8 @@ public class SmartupSyncService(
 
     // ── Products ──────────────────────────────────────────────────────────
 
+    private const int MaxSyncPages = 500;
+
     private async Task<(int created, int updated, int errors, List<object> details)> SyncProductsAsync(
         List<SmartupCategoryItem> categories,
         Dictionary<string, long> categoryIdMap,
@@ -198,7 +200,22 @@ public class SmartupSyncService(
                 }
 
                 var envelope = call.Result.Data!;
-                pageCount = envelope.GetPageCount();
+
+                if (page == 1)
+                {
+                    var rawPageCount = envelope.GetPageCount();
+                    if (rawPageCount > MaxSyncPages)
+                    {
+                        logger.LogWarning(
+                            "Smartup Sync [{LogId}]: category {TypeId} reports {Pages} pages — capping at {Max}",
+                            logId, cat.ProductTypeId, rawPageCount, MaxSyncPages);
+                        pageCount = MaxSyncPages;
+                    }
+                    else
+                    {
+                        pageCount = rawPageCount;
+                    }
+                }
 
                 var (c, u) = await UpsertProductsAsync(envelope.Products, categoryId, cancellationToken);
                 catCreated += c;


### PR DESCRIPTION
## Summary

Fixes #75

`SmartupSyncService.SyncProductsAsync` re-read `pageCount` from the external API on every loop iteration with no upper-bound guard. If the Smartup API returned an unexpectedly large or growing page count (due to a bug, data corruption, or a malicious response), the loop would run indefinitely — making thousands of HTTP calls and `SaveChangesAsync` calls per category, exhausting API quota, filling the `SyncLog` table, and monopolizing the Hangfire worker thread.

## Fix

Two changes in `SyncProductsAsync`:

1. **Read `pageCount` only from the first page response** — the `if (page == 1)` guard prevents mid-loop manipulation by the API.
2. **Cap `pageCount` at `MaxSyncPages = 500`** — logs a `LogWarning` when the cap is applied so the condition is visible in sync logs without being silent.

```csharp
private const int MaxSyncPages = 500;

// Inside the loop, replacing pageCount = envelope.GetPageCount():
if (page == 1)
{
    var rawPageCount = envelope.GetPageCount();
    if (rawPageCount > MaxSyncPages)
    {
        logger.LogWarning(
            "Smartup Sync [{LogId}]: category {TypeId} reports {Pages} pages — capping at {Max}",
            logId, cat.ProductTypeId, rawPageCount, MaxSyncPages);
        pageCount = MaxSyncPages;
    }
    else
    {
        pageCount = rawPageCount;
    }
}
```

## Files Changed

- `src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs` — `SyncProductsAsync` and a new `MaxSyncPages` constant

## Verification

Fix verified by code inspection. The loop behavior is unchanged for normal catalogs (≤ 500 pages); for larger ones the cap kicks in and a warning is emitted.

## Risks / Assumptions

- `MaxSyncPages = 500` is a conservative limit; adjust if the Smartup catalog legitimately exceeds this in production. It can be promoted to a configurable `SmartupOptions` field if needed.
- The loop already respects `CancellationToken` on each `GetProductsAsync` call, so graceful shutdown still works regardless of page count.
- No migration required.

---
_Generated by [Claude Code](https://claude.ai/code/session_012UeoyLqueSLQyTPPc6QRbe)_