### PR TITLE
Fix #63: Add Admin/Manager role requirement to AdminController base class

### DIFF
--- a/src/VendlyServer.Api/Controllers/Common/AdminController.cs
+++ b/src/VendlyServer.Api/Controllers/Common/AdminController.cs
@@ -1,5 +1,8 @@
+using Microsoft.AspNetCore.Authorization;
+
 namespace VendlyServer.Api.Controllers.Common;
 
+[Authorize(Roles = "Admin,Manager")]
 public abstract class AdminController : AuthorizedController
 {
 }


### PR DESCRIPTION
## Summary

Fixes #63

`SyncLogsController` was accessible to any authenticated user (any valid JWT) because `AdminController` only inherited `[Authorize]` from `AuthorizedController` with no role restriction. This allowed any registered customer to:
- List all sync log entries (`GET /api/admin/sync-logs`)
- Read raw Smartup API request/response bodies and error details (`GET /api/admin/sync-logs/{id}`)
- Enqueue unlimited background sync jobs (`POST /api/admin/sync-logs/trigger`), consuming Smartup API quota and hammering the database

The trigger endpoint is especially high-risk: rate limits on the Smartup API can be exhausted by any registered user.

## Fix

Added `[Authorize(Roles = "Admin,Manager")]` to `AdminController` itself:

```csharp
[Authorize(Roles = "Admin,Manager")]
public abstract class AdminController : AuthorizedController
```

This protects all current and future controllers that inherit from `AdminController` without requiring per-action attributes, matching the intent of having a dedicated base class for admin endpoints.

## Files Changed

- `src/VendlyServer.Api/Controllers/Common/AdminController.cs` — added `[Authorize(Roles = "Admin,Manager")]` (+2 lines including the `using`)

## Verification

Fix verified by code inspection. `[Authorize]` attributes stack in ASP.NET Core — the role constraint on `AdminController` adds to (not replaces) the `[Authorize]` on `AuthorizedController`. Any request to a `SyncLogsController` endpoint now requires a valid JWT **and** the `Admin` or `Manager` role claim.

## Risks / Assumptions

- `UsersController` uses per-action `[Authorize(Roles = "Admin,Manager")]` attributes. Those are redundant after this change but harmless — they remain in place.
- No migration required.

---
_Generated by [Claude Code](https://claude.ai/code/session_012UeoyLqueSLQyTPPc6QRbe)_