### PR TITLE
Fix #56: Validate RedirectUrl is HTTPS before embedding in Telegram inline keyboard

### DIFF
--- a/src/VendlyServer.Application/Services/Telegram/TelegramUpdateHandler.cs
+++ b/src/VendlyServer.Application/Services/Telegram/TelegramUpdateHandler.cs
@@ -309,6 +309,10 @@ public sealed class TelegramUpdateHandler(
 
     private static TelegramInlineKeyboardMarkup BuildOpenProductKeyboard(string redirectUrl, long? refChatId)
     {
+        var url = BuildProductRedirectUrl(redirectUrl, refChatId);
+        if (url is null)
+            return new TelegramInlineKeyboardMarkup();
+
         return new TelegramInlineKeyboardMarkup
         {
             InlineKeyboard =
@@ -317,15 +321,18 @@ public sealed class TelegramUpdateHandler(
                     new TelegramInlineKeyboardButton
                     {
                         Text = "🛍️ Mahsulotni ochish",
-                        Url = BuildProductRedirectUrl(redirectUrl, refChatId)
+                        Url = url
                     }
                 ]
             ]
         };
     }
 
-    private static string BuildProductRedirectUrl(string redirectUrl, long? refChatId)
+    private static string? BuildProductRedirectUrl(string redirectUrl, long? refChatId)
     {
+        if (!Uri.TryCreate(redirectUrl, UriKind.Absolute, out var uri) || uri.Scheme != "https")
+            return null;
+
         if (!refChatId.HasValue)
             return redirectUrl;
 


### PR DESCRIPTION
Fixes #56

## Summary

- `BuildProductRedirectUrl` now validates that `redirectUrl` is a valid absolute `https://` URL before using it. If the URL fails validation, it returns `null`.
- `BuildOpenProductKeyboard` handles the `null` case by returning a `TelegramInlineKeyboardMarkup` with an empty `InlineKeyboard` (no button rendered), preventing any non-HTTPS or malformed URL from reaching end users via the Telegram inline keyboard.

This is a defence-in-depth fix consistent with the existing `IsTelegramFetchableImageUrl` guard that already protects thumbnail image URLs.

## Files Changed

- `src/VendlyServer.Application/Services/Telegram/TelegramUpdateHandler.cs`
  - `BuildProductRedirectUrl`: signature changed to `string?`, HTTPS validation added
  - `BuildOpenProductKeyboard`: null-URL guard added

## Verification

`dotnet build` — SDK not available in this environment. Change is a self-contained two-method edit with no new dependencies; logic was manually verified against the existing `IsTelegramFetchableImageUrl` pattern in the same file.

## Risks / Assumptions

- If `product.RedirectUrl` is always generated server-side as a valid `https://` URL (the most likely case), this change is a no-op in practice.
- If any existing product has a non-HTTPS `RedirectUrl` stored in the DB, the Telegram inline button for that product will disappear rather than show a potentially unsafe link. This is the correct safe-fail behaviour.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCJ6uK1Sd3vPCasoVy7qe9)_