### PR TITLE
Fix #80: Document implicit cart delete-by-zero and improve sync error logging

### DIFF
--- a/src/VendlyServer.Api/Controllers/Catalog/CartsController.cs
+++ b/src/VendlyServer.Api/Controllers/Catalog/CartsController.cs
@@ -26,7 +26,7 @@ public class CartsController(ICartService cartService) : AuthorizedController
         return result.IsSuccess ? Results.Ok(result.Data) : result.ToProblemDetails();
     }
 
-    /// <summary>Update cart item quantity.</summary>
+    /// <summary>Update cart item quantity. Sending Qty = 0 soft-deletes the item (equivalent to DELETE /items/{id}).</summary>
     [HttpPut("items/{id:long}")]
     public async Task<IResult> UpdateItemAsync(
         long id,

--- a/src/VendlyServer.Application/Jobs/SmartupCatalog/SmartupCatalogSyncJob.cs
+++ b/src/VendlyServer.Application/Jobs/SmartupCatalog/SmartupCatalogSyncJob.cs
@@ -14,6 +14,9 @@ public class SmartupCatalogSyncJob(
         var result = await smartupSyncService.SyncAsync(cancellationToken);
 
         if (result.IsFailure)
-            logger.LogError("Smartup Catalog Sync job failed: {Error}", result.Error.Code);
+            logger.LogError(
+                "Smartup Catalog Sync job failed: [{Code}] {Message}",
+                result.Error.Code,
+                result.Error.Message);
     }
 }


### PR DESCRIPTION
Fixes #80

## Summary

Two findings from the automated review, both addressed:

**Finding 1 — `UpdateCartItemRequest` implicit delete-by-zero undocumented**

A validator (`UpdateCartItemRequestValidator` with `GreaterThanOrEqualTo(0)`) already existed in the codebase, so the API boundary guard is in place. What was missing was visibility into the intentional `Qty = 0 → soft-delete` contract. The `UpdateItemAsync` XML summary now makes this explicit so API clients and Swagger docs reflect the actual behaviour.

**Finding 2 — `SmartupCatalogSyncJob` discards error description on failure**

The job logged only `result.Error.Code`, producing identical log lines like `"Smartup Catalog Sync job failed: SmartupApiError"` with no root-cause detail. Now logs both `Code` and `Message` as structured log properties, matching the `Error` record's fields.

## Files Changed

- `src/VendlyServer.Api/Controllers/Catalog/CartsController.cs` — updated `UpdateItemAsync` XML summary
- `src/VendlyServer.Application/Jobs/SmartupCatalog/SmartupCatalogSyncJob.cs` — log both Code and Message on failure

## Verification

`dotnet build` — SDK not available in this environment. Both changes are minimal text edits with no logic changes; reviewed manually for correctness.

## Risks / Assumptions

- The validator with `>= 0` is the intentional design (Qty = 0 triggers soft-delete). No change was made to the validation rule itself.
- `result.Error.Message` may be `null` for errors created with `Error.Failure(code)` (no message param). Structured logging handles null values correctly — the `{Message}` property will appear as empty in that case.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCJ6uK1Sd3vPCasoVy7qe9)_