### PR TITLE
Fix #102: AddressService.UpdateAsync — IsDefault flag is irreversible once set

### DIFF
--- a/src/VendlyServer.Application/Services/Addresses/AddressService.cs
+++ b/src/VendlyServer.Application/Services/Addresses/AddressService.cs
@@ -146,7 +146,7 @@ public class AddressService(AppDbContext dbContext) : IAddressService
         address.House = request.House;
         address.Extra = request.Extra;
         address.BtsCityCode = request.BtsCityCode;
-        address.IsDefault = request.IsDefault || address.IsDefault;
+        address.IsDefault = request.IsDefault;
 
         await dbContext.SaveChangesAsync(cancellationToken);
 


### PR DESCRIPTION
Fixes #102
Fixes #78

## Summary

- `AddressService.UpdateAsync` used a boolean OR to set `IsDefault`, making it a one-way ratchet: once an address was marked as default, sending `IsDefault: false` silently had no effect.
- Replaced `address.IsDefault = request.IsDefault || address.IsDefault` with the direct assignment `address.IsDefault = request.IsDefault`.
- The existing guard block (lines 132–140) that clears other default addresses when promoting to default is preserved and still functions correctly.

## Files changed

- `src/VendlyServer.Application/Services/Addresses/AddressService.cs` — line 149: one-character logic fix

## Verification

The .NET 10 SDK is not installed in this execution environment so `dotnet build` could not be run. The change is a single-line assignment replacement with no new types, methods, or dependencies introduced. The surrounding logic (clear-other-defaults guard) is untouched.

## Risks / assumptions

- Clients that were relying on the silent "can't unset default" behavior will now be able to unset it. This is the intended behavior described in the issue.
- No migration needed: no schema change.
- A user can now have zero default addresses if they explicitly unset the only default. If the product requires at least one default, a validation rule rejecting `IsDefault: false` when no other default exists should be added separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj3FEoU5ZmEgF1mmzTbAFu)_