### PR TITLE
Fix #88: SyncCategoriesAsync — ContinueWith wraps cancellation in AggregateException

### DIFF
--- a/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
+++ b/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
@@ -147,12 +147,13 @@ public class SmartupSyncService(
         logger.LogInformation("Smartup Sync [{LogId}]: categories — +{Created} ~{Updated}",
             logId, created, updated);
 
-        var idMap = await dbContext.Categories
+        var allCats = await dbContext.Categories
             .Where(c => !c.IsDeleted && c.Metadata != null)
-            .ToListAsync(cancellationToken)
-            .ContinueWith(t => t.Result
-                .Where(c => TryGetSourceId(c.Metadata, out _))
-                .ToDictionary(c => GetSourceId(c.Metadata)!, c => c.Id));
+            .ToListAsync(cancellationToken);
+
+        var idMap = allCats
+            .Where(c => TryGetSourceId(c.Metadata, out _))
+            .ToDictionary(c => GetSourceId(c.Metadata)!, c => c.Id);
 
         return (idMap, created, updated);
     }


### PR DESCRIPTION
Fixes #88

## Summary

`SmartupSyncService.SyncCategoriesAsync` chained `.ContinueWith()` directly onto `ToListAsync(cancellationToken)`. When the cancellation token fires, `ToListAsync` transitions to a cancelled/faulted state and `.ContinueWith` accesses `t.Result`, which raises `AggregateException` instead of propagating the expected `OperationCanceledException`. This breaks the standard .NET cancellation contract and confuses the Hangfire job runner's retry and error-handling logic.

**Fix:** split the chain into two steps — await the query first, then apply the in-memory LINQ projection. The result is semantically identical but correctly propagates `OperationCanceledException` on cancellation.

## Files changed

- `src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs` — lines 150–155: replaced `ContinueWith` chain with two-step await + LINQ

## Verification

The .NET 10 SDK is not installed in this execution environment so `dotnet build` could not be run. The change is a mechanical split of an existing fluent chain into two statements with identical logic and no new types or dependencies.

## Risks / assumptions

- No behavioral change under normal (non-cancelled) execution.
- Cancellation now propagates correctly as `OperationCanceledException`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kj3FEoU5ZmEgF1mmzTbAFu)_