### PR TITLE
Fix #46: handle null query in ProductService.SearchAsync

### DIFF
--- a/src/VendlyServer.Application/Services/Products/IProductService.cs
+++ b/src/VendlyServer.Application/Services/Products/IProductService.cs
@@ -7,7 +7,7 @@ public interface IProductService
 {
     Task<PagedList<ProductCardResponse>> GetAllAsync(ProductFilterRequest request, CancellationToken ct = default);
     Task<Result<List<ProductListResponse>>> GetAllAdminAsync(CancellationToken ct = default);
-    Task<Result<List<ProductSearchResponse>>> SearchAsync(string query, CancellationToken ct = default);
+    Task<Result<List<ProductSearchResponse>>> SearchAsync(string? query, CancellationToken ct = default);
     Task<Result<ProductAdminDetailResponse>> GetByIdAsync(long id, CancellationToken ct = default);
     Task<Result<long>> CreateAsync(CreateProductRequest request, CancellationToken ct = default);
     Task<Result> UpdateAsync(long id, UpdateProductRequest request, CancellationToken ct = default);

--- a/src/VendlyServer.Application/Services/Products/ProductService.cs
+++ b/src/VendlyServer.Application/Services/Products/ProductService.cs
@@ -79,9 +79,9 @@ public class ProductService(
         return products;
     }
 
-    public async Task<Result<List<ProductSearchResponse>>> SearchAsync(string query, CancellationToken ct = default)
+    public async Task<Result<List<ProductSearchResponse>>> SearchAsync(string? query, CancellationToken ct = default)
     {
-        var normalizedQuery = query.Trim().ToLower();
+        var normalizedQuery = query?.Trim().ToLower() ?? string.Empty;
 
         if (string.IsNullOrWhiteSpace(normalizedQuery) || normalizedQuery.Length < 2)
             return new List<ProductSearchResponse>();


### PR DESCRIPTION
## Summary

Fixes #46

`GET /api/products/search` without a `?q=` parameter bound `string q` as `null` in the controller. The service then called `query.Trim().ToLower()` immediately, throwing `NullReferenceException` and returning HTTP 500 from this public, unauthenticated endpoint.

## Changes

- `IProductService.SearchAsync`: parameter type changed from `string` to `string?`
- `ProductService.SearchAsync`: parameter type changed to `string?`; null-coalescing `?.Trim().ToLower() ?? string.Empty` before the existing `IsNullOrWhiteSpace` guard

## Files Changed

- `src/VendlyServer.Application/Services/Products/IProductService.cs`
- `src/VendlyServer.Application/Services/Products/ProductService.cs`

## Verification

- Reviewed fix against the null-coalescing pattern; the empty-string result hits the existing `IsNullOrWhiteSpace || length < 2` guard and returns `[]` with HTTP 200 (no exception).
- `dotnet build` not available in this environment; correctness verified by static review.

## Risks / Assumptions

None. The downstream guard was already in place; this fix only prevents the NPE before reaching it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDu391ELoXRnp3dguGuKSW)_