### PR TITLE
Fix #105: replace .First() with dictionary lookup in BulkUpdateVariantsAsync

### DIFF
--- a/src/VendlyServer.Application/Services/Products/ProductService.cs
+++ b/src/VendlyServer.Application/Services/Products/ProductService.cs
@@ -393,9 +393,11 @@ public class ProductService(
         if (variants.Count != requestedIds.Count)
             return ProductErrors.VariantNotFound;
 
+        var variantById = variants.ToDictionary(v => v.Id);
+
         foreach (var item in request.Variants)
         {
-            var variant = variants.First(v => v.Id == item.Id);
+            var variant = variantById[item.Id];
             variant.Name = item.Name;
             variant.Price = item.Price;
             variant.Quantity = item.Quantity;


### PR DESCRIPTION
## Summary

Fixes #105

`BulkUpdateVariantsAsync` used `.First(v => v.Id == item.Id)` to look up each variant from an in-memory list. The project coding standards explicitly forbid `.First()` and require `.SingleOrDefault()` / dictionary lookups. Beyond the style violation, `.First()` silently returns the wrong record on duplicate IDs instead of surfacing the integrity issue.

## Changes

- Pre-build a `Dictionary<long, ProductVariant>` from the loaded variants list before the loop
- Replace `variants.First(v => v.Id == item.Id)` with `variantById[item.Id]`

## Files Changed

- `src/VendlyServer.Application/Services/Products/ProductService.cs`

## Verification

- The pre-check `if (variants.Count != requestedIds.Count) return ProductErrors.VariantNotFound` guarantees every `item.Id` is present in the dictionary, so the indexer will never throw `KeyNotFoundException` in practice.
- O(1) per lookup vs O(n) previously — minor improvement for large bulk requests.

## Risks / Assumptions

None. The guard before the loop guarantees all IDs are present.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDu391ELoXRnp3dguGuKSW)_