### PR TITLE
Fix #102: allow unsetting IsDefault in AddressService.UpdateAsync

### DIFF
--- a/src/VendlyServer.Application/Services/Addresses/AddressService.cs
+++ b/src/VendlyServer.Application/Services/Addresses/AddressService.cs
@@ -146,7 +146,7 @@ public class AddressService(AppDbContext dbContext) : IAddressService
         address.House = request.House;
         address.Extra = request.Extra;
         address.BtsCityCode = request.BtsCityCode;
-        address.IsDefault = request.IsDefault || address.IsDefault;
+        address.IsDefault = request.IsDefault;
 
         await dbContext.SaveChangesAsync(cancellationToken);
 


### PR DESCRIPTION
## Summary

Fixes #102
Also fixes #78 (same root cause reported in two separate review issues)

`AddressService.UpdateAsync` used `address.IsDefault = request.IsDefault || address.IsDefault`. This OR expression made `IsDefault` a one-way ratchet: once set to `true`, it could never be cleared via the update endpoint regardless of what the client sent. A `PUT /api/addresses/{id}` with `"isDefault": false` on the current default returned HTTP 200 but silently kept the field as `true`.

## Changes

- Replace `request.IsDefault || address.IsDefault` with the direct assignment `request.IsDefault`
- The existing guard block that clears sibling addresses' `IsDefault` when promoting a new default is unchanged and remains correct

## Files Changed

- `src/VendlyServer.Application/Services/Addresses/AddressService.cs`

## Verification

| `request.IsDefault` | `address.IsDefault` (before) | Result after fix |
|---|---|---|
| `true` | `false` | `true` ✓ (promotes to default, clears siblings) |
| `true` | `true` | `true` ✓ (no-op) |
| `false` | `false` | `false` ✓ (no change) |
| `false` | `true` | `false` ✓ (now correctly unsets — was broken before) |

## Risks / Assumptions

This is a behavioral change. Callers that relied on the broken one-way behavior are implicitly fixed. No client should break unless it was deliberately sending `isDefault: false` on a default address and expecting the flag to stay `true`, which would be an incorrect expectation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDu391ELoXRnp3dguGuKSW)_