### PR TITLE
Fix #84: add email uniqueness check in AuthService.RegisterAsync

### DIFF
--- a/src/VendlyServer.Application/Services/Auth/AuthService.cs
+++ b/src/VendlyServer.Application/Services/Auth/AuthService.cs
@@ -20,7 +20,7 @@ public class AuthService(
     {
         var user = await dbContext.Users
             .AsNoTracking()
-            .SingleOrDefaultAsync(u => (u.Phone == request.Login || u.Email == request.Login) && !u.IsDeleted, cancellationToken);
+            .FirstOrDefaultAsync(u => (u.Phone == request.Login || u.Email == request.Login) && !u.IsDeleted, cancellationToken);
 
         if (user is null || !passwordHasher.Verify(request.Password, user.PasswordHash))
             return AuthErrors.InvalidCredentials;
@@ -33,11 +33,20 @@ public class AuthService(
 
     public async Task<Result<AuthResponse>> RegisterAsync(RegisterRequest request, CancellationToken cancellationToken = default)
     {
-        var exists = await dbContext.Users
+        var phoneExists = await dbContext.Users
             .AsNoTracking()
             .AnyAsync(u => u.Phone == request.Phone && !u.IsDeleted, cancellationToken);
 
-        if (exists) return AuthErrors.UserAlreadyExists;
+        if (phoneExists) return AuthErrors.UserAlreadyExists;
+
+        if (!string.IsNullOrWhiteSpace(request.Email))
+        {
+            var emailExists = await dbContext.Users
+                .AsNoTracking()
+                .AnyAsync(u => u.Email == request.Email && !u.IsDeleted, cancellationToken);
+
+            if (emailExists) return AuthErrors.UserAlreadyExists;
+        }
 
         var user = new User
         {


### PR DESCRIPTION
## Summary

Fixes #84

`AuthService.RegisterAsync` checked for phone uniqueness but not email uniqueness. Two users with different phones but the same email could both register successfully. `LoginAsync` used `SingleOrDefaultAsync` on a query with an `Email == request.Login` OR condition — with two matching rows, this throws `InvalidOperationException`, causing HTTP 500 for all future email-based logins for both affected accounts.

## Changes

- `RegisterAsync`: add `AnyAsync` email uniqueness check before inserting a new user (only when `request.Email` is non-empty)
- `LoginAsync`: downgrade `SingleOrDefaultAsync` to `FirstOrDefaultAsync` as a defensive guard against any pre-existing duplicate-email rows

## Files Changed

- `src/VendlyServer.Application/Services/Auth/AuthService.cs`

## Verification

- New registration with a duplicate email returns `AuthErrors.UserAlreadyExists` (same error as duplicate phone)
- If any duplicate-email rows already exist in production, `FirstOrDefaultAsync` in `LoginAsync` prevents the 500 and allows the first matching user to log in

## Risks / Assumptions

- A DB-level unique partial index on `Users.Email` (where `Email IS NOT NULL AND IsDeleted = false`) would enforce this at the persistence layer and is recommended as a follow-up migration, but is not included in this fix to keep the change bounded.
- `FirstOrDefaultAsync` in `LoginAsync` is a non-breaking fallback; it does not change the happy path for users with unique emails.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDu391ELoXRnp3dguGuKSW)_