### PR TITLE
Fix #63: add role-based authorization to SyncLogsController

### DIFF
--- a/src/VendlyServer.Api/Controllers/Admin/SyncLogsController.cs
+++ b/src/VendlyServer.Api/Controllers/Admin/SyncLogsController.cs
@@ -1,4 +1,5 @@
 using Hangfire;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using VendlyServer.Api.Controllers.Common;
 using VendlyServer.Application.Jobs.SmartupCatalog;
@@ -9,6 +10,7 @@ namespace VendlyServer.Api.Controllers.Admin;
 
 [ApiController]
 [Route("api/admin/sync-logs")]
+[Authorize(Roles = "Admin,Manager")]
 public class SyncLogsController(ISyncLogService syncLogService) : AdminController
 {
     /// <summary>


### PR DESCRIPTION
## Summary

Fixes #63

`SyncLogsController` inherited only `[Authorize]` (any valid JWT) from `AdminController`. Any authenticated user — including Customers — could:
- `GET /api/admin/sync-logs` — list all sync log entries
- `GET /api/admin/sync-logs/{id}` — read full Smartup request/response payloads and error details
- `POST /api/admin/sync-logs/trigger` — enqueue unlimited Smartup sync jobs, exhausting API quota and hammering the database

## Changes

- Add `[Authorize(Roles = "Admin,Manager")]` attribute to `SyncLogsController` class
- Add `using Microsoft.AspNetCore.Authorization` import

## Files Changed

- `src/VendlyServer.Api/Controllers/Admin/SyncLogsController.cs`

## Verification

The pattern matches `UsersController` in the same `Admin/` folder, which applies per-action role attributes. Class-level attribute is the simpler and more reliable approach (no individual action is missed).

## Risks / Assumptions

None. This is a security hardening change with no functional impact on Admin/Manager users.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDu391ELoXRnp3dguGuKSW)_