### PR TITLE
Fix #54: guard fallback send in SendStartMessageAsync against exceptions

### DIFF
--- a/src/VendlyServer.Application/Services/Telegram/TelegramUpdateHandler.cs
+++ b/src/VendlyServer.Application/Services/Telegram/TelegramUpdateHandler.cs
@@ -110,10 +110,20 @@ public sealed class TelegramUpdateHandler(
                 "Failed to send Telegram rich start message to chat {ChatId}. Sending fallback message.",
                 message.Chat.Id);
 
-            await botClient.SendMessageAsync(
-                message.Chat.Id,
-                BuildFallbackStartMessage(emoji),
-                cancellationToken);
+            try
+            {
+                await botClient.SendMessageAsync(
+                    message.Chat.Id,
+                    BuildFallbackStartMessage(emoji),
+                    cancellationToken);
+            }
+            catch (Exception fallbackEx) when (fallbackEx is HttpRequestException or TaskCanceledException)
+            {
+                logger.LogWarning(
+                    fallbackEx,
+                    "Failed to send Telegram fallback start message to chat {ChatId}. Giving up.",
+                    message.Chat.Id);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #54

The fallback `botClient.SendMessageAsync` call inside the `catch` block of `SendStartMessageAsync` was unguarded. If it also threw (`HttpRequestException`, `TaskCanceledException` from the webhook request's cancellation token, or a Telegram API rate-limit), the exception propagated through `HandleMessageAsync` → `HandleAsync` → the controller, producing HTTP 500. Telegram treats 5xx as delivery failures and retries the webhook, amplifying the failure under an already-degraded Telegram API connection.

## Changes

- Wrap the fallback `SendMessageAsync` call in its own `try/catch` matching the outer guard pattern
- Log a warning if the fallback also fails, then let the handler return normally (HTTP 200 to Telegram)

## Files Changed

- `src/VendlyServer.Application/Services/Telegram/TelegramUpdateHandler.cs`

## Verification

- Consistent with `TrySetStartReactionAsync` which already uses an inner try/catch for a similar pattern
- A failing fallback logs a warning and the handler exits cleanly — Telegram receives 200 and does not retry

## Risks / Assumptions

None. This is a pure defensive hardening change with no user-visible behavior change under normal conditions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDu391ELoXRnp3dguGuKSW)_