### PR TITLE
Fix #35: derive MinIO ContentType from file extension, not client header

### DIFF
--- a/src/VendlyServer.Application/Services/Storages/MinioStorageService.cs
+++ b/src/VendlyServer.Application/Services/Storages/MinioStorageService.cs
@@ -13,6 +13,15 @@ public class MinioStorageService(
     private readonly MinioOptions _minio = minioOptions.Value;
     private readonly StorageOptions _storage = storageOptions.Value;
 
+    private static readonly Dictionary<string, string> MimeMap = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [".jpg"]  = "image/jpeg",
+        [".jpeg"] = "image/jpeg",
+        [".png"]  = "image/png",
+        [".webp"] = "image/webp",
+        [".svg"]  = "image/svg+xml",
+    };
+
     public async Task<Result<string>> UploadAsync(
         IFormFile file,
         string folder,
@@ -26,6 +35,7 @@ public class MinioStorageService(
         if (file.Length > _storage.MaxFileSizeBytes)
             return StorageErrors.FileTooLarge;
 
+        var contentType = MimeMap.TryGetValue(extension, out var mime) ? mime : "application/octet-stream";
         var fileName = $"{Guid.NewGuid()}{extension}";
         var objectKey = $"{folder.Trim('/')}/{fileName}";
 
@@ -38,7 +48,7 @@ public class MinioStorageService(
                 .WithObject(objectKey)
                 .WithStreamData(stream)
                 .WithObjectSize(file.Length)
-                .WithContentType(file.ContentType ?? "application/octet-stream");
+                .WithContentType(contentType);
 
             await minioClient.PutObjectAsync(args, cancellationToken);
         }


### PR DESCRIPTION
## Summary

Fixes #35

`MinioStorageService.UploadAsync` passed `file.ContentType` — taken directly from the multipart `Content-Type` request header — to MinIO as the stored object's content type. This is fully attacker-controlled. An Admin/Manager user could upload a file named `exploit.jpg` with `Content-Type: text/html` containing JavaScript. MinIO stores it with `Content-Type: text/html`. The publicly-accessible bucket then serves it to any browser as HTML, executing the payload — stored XSS in the `files.vestor.uz` origin.

## Changes

- Add a `MimeMap` dictionary mapping allowed extensions to their canonical MIME types
- Derive `contentType` from the validated extension server-side before constructing the `PutObjectArgs`
- Replace `file.ContentType ?? "application/octet-stream"` with the server-derived value

## Files Changed

- `src/VendlyServer.Application/Services/Storages/MinioStorageService.cs`

## Verification

- The extension has already been validated against `AllowedExtensions` at this point; the `MimeMap` covers all entries in the default `AllowedExtensions` list (`.jpg`, `.jpeg`, `.png`, `.webp`, `.svg`)
- Any extension not in `MimeMap` falls back to `application/octet-stream`, which is safe (browsers will not render it inline as HTML)

## Risks / Assumptions

- Any previously uploaded objects in MinIO retain their (potentially wrong) stored content types; this fix only affects new uploads
- `UploadFromStreamAsync` uses a caller-supplied `contentType` parameter (used internally by the Smartup sync image pipeline, not from user input) and is unchanged — callers there control the MIME type from known image downloads

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDu391ELoXRnp3dguGuKSW)_