### PR TITLE
Fix #101: CartService stock-check TOCTOU — serializable transactions

### DIFF
--- a/src/VendlyServer.Application/Services/Carts/CartService.cs
+++ b/src/VendlyServer.Application/Services/Carts/CartService.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using Microsoft.EntityFrameworkCore;
 using VendlyServer.Application.Services.Carts.Contracts;
 using VendlyServer.Domain.Abstractions;
@@ -24,6 +25,8 @@ public class CartService(AppDbContext dbContext) : ICartService
 
     public async Task<Result<CartResponse>> AddItemAsync(long userId, CartItemRequest request, CancellationToken cancellationToken = default)
     {
+        await using var tx = await dbContext.Database.BeginTransactionAsync(IsolationLevel.Serializable, cancellationToken);
+
         var variant = await dbContext.ProductVariants
             .AsNoTracking()
             .Where(v => v.Id == request.ProductVariantId && !v.IsDeleted && v.IsActive)
@@ -63,6 +66,7 @@ public class CartService(AppDbContext dbContext) : ICartService
         }
 
         await dbContext.SaveChangesAsync(cancellationToken);
+        await tx.CommitAsync(cancellationToken);
 
         var updated = await FindCartWithItemsAsync(userId, cancellationToken);
         return MapToResponse(updated!);
@@ -70,6 +74,8 @@ public class CartService(AppDbContext dbContext) : ICartService
 
     public async Task<Result<CartResponse>> UpdateItemAsync(long userId, long cartItemId, UpdateCartItemRequest request, CancellationToken cancellationToken = default)
     {
+        await using var tx = await dbContext.Database.BeginTransactionAsync(IsolationLevel.Serializable, cancellationToken);
+
         var cart = await dbContext.Carts
             .Where(c => c.UserId == userId && !c.IsDeleted)
             .Include(c => c.Items.Where(i => !i.IsDeleted))
@@ -93,6 +99,7 @@ public class CartService(AppDbContext dbContext) : ICartService
         }
 
         await dbContext.SaveChangesAsync(cancellationToken);
+        await tx.CommitAsync(cancellationToken);
         return MapToResponse(cart);
     }
 


### PR DESCRIPTION
## Summary

Fixes #101. Also addresses finding 1 from #79.

`CartService.AddItemAsync` and `UpdateItemAsync` read `variant.Quantity` (stock level) in one database round-trip and write the cart item in a separate round-trip. Two concurrent requests from the same user can both pass the `InsufficientStock` guard and both commit, resulting in a combined cart quantity that exceeds actual stock (overselling).

**Fix:** Both mutating methods are now wrapped in `IsolationLevel.Serializable` transactions. PostgreSQL's Serializable Snapshot Isolation (SSI) detects the rw-anti-dependency cycle between the two concurrent reads of `cart_items` and their subsequent inserts/updates, and aborts one of the conflicting transactions before it can commit. On conflict, the aborted transaction surfaces as a `DbUpdateException` which is caught by the global exception handler (→ HTTP 500), which is correct behaviour — the client can retry.

Early returns (`CartErrors.VariantNotFound`, `CartErrors.InsufficientStock`) trigger automatic transaction rollback via `await using` disposal before any data is written.

## Files Changed

- `src/VendlyServer.Application/Services/Carts/CartService.cs`
  - Added `using System.Data;`
  - `AddItemAsync`: begin `Serializable` tx → existing logic unchanged → `SaveChangesAsync` → `CommitAsync`
  - `UpdateItemAsync`: same pattern

## Verification

.NET SDK is not available in the remote execution environment; build and test could not be run locally.

Code correctness was verified by inspection:
- `System.Data.IsolationLevel.Serializable` is the correct enum value for EF Core's `BeginTransactionAsync` overload
- `await using var tx` guarantees rollback on early return or exception (no explicit `RollbackAsync` needed)
- `CommitAsync` is called only after the final `SaveChangesAsync` succeeds
- `FindCartWithItemsAsync` after `CommitAsync` runs outside the serializable tx, which is correct (read-only response projection)

## Remaining Risks / Assumptions

- Under high concurrency the aborted transaction returns HTTP 500 rather than a retryable domain error. A future improvement could catch `NpgsqlException { SqlState = "40001" }` and return `CartErrors.InsufficientStock` with HTTP 409 for better client UX.
- `GetOrCreateAsync` is not wrapped because it has no stock-validation logic; a concurrent "first cart creation" edge case is a separate, lower-priority concern.
- The fix does not add a DB-level constraint (as recommended in issue #101 as a second line of defence). That requires a migration and is deferred to a separate task.

https://claude.ai/code/session_01LQNkxgJtAj3kGfVjowHVwa

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQNkxgJtAj3kGfVjowHVwa)_