### PR TITLE
Fix #79: AddressService per-user count-check TOCTOU — serializable transaction

### DIFF
--- a/src/VendlyServer.Application/Services/Addresses/AddressService.cs
+++ b/src/VendlyServer.Application/Services/Addresses/AddressService.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using Microsoft.EntityFrameworkCore;
 using VendlyServer.Application.Services.Addresses.Contracts;
 using VendlyServer.Domain.Abstractions;
@@ -63,8 +64,9 @@ public class AddressService(AppDbContext dbContext) : IAddressService
         if (!btsCityExists)
             return AddressErrors.BtsCityCodeInvalid;
 
+        await using var tx = await dbContext.Database.BeginTransactionAsync(IsolationLevel.Serializable, cancellationToken);
+
         var existingCount = await dbContext.Addresses
-            .AsNoTracking()
             .CountAsync(a => a.UserId == userId && !a.IsDeleted, cancellationToken);
 
         if (existingCount >= MaxAddressesPerUser)
@@ -97,6 +99,7 @@ public class AddressService(AppDbContext dbContext) : IAddressService
 
         dbContext.Addresses.Add(address);
         await dbContext.SaveChangesAsync(cancellationToken);
+        await tx.CommitAsync(cancellationToken);
 
         return new AddressResponse(
             address.Id,


### PR DESCRIPTION
## Summary

Fixes #79 (finding 2 — address count TOCTOU).

`AddressService.AddAsync` reads the user's address count with `AsNoTracking()` and then inserts a new address in separate database operations. Two concurrent `POST /api/addresses` requests from the same user can both read `existingCount = 9`, both pass the `LimitReached` guard, and both insert — leaving the user with 11 addresses instead of the `MaxAddressesPerUser = 10` cap.

**Fix:** A `IsolationLevel.Serializable` transaction now wraps the count read through `SaveChangesAsync`. PostgreSQL SSI detects the rw-anti-dependency cycle between the two concurrent reads of the `addresses` table and their subsequent inserts, aborting one of the conflicting transactions. On conflict, the global exception handler returns HTTP 500; the client can retry.

The `BtsCityCode` validation query remains outside the transaction because it reads a stable reference table and is not part of the limit-enforcement logic.

Also removes the now-unnecessary `AsNoTracking()` on the `CountAsync` call (inside a tracking transaction context it was a no-op).

## Files Changed

- `src/VendlyServer.Application/Services/Addresses/AddressService.cs`
  - Added `using System.Data;`
  - `AddAsync`: begin `Serializable` tx after BtsCity validation → `CountAsync` (without `AsNoTracking`) → existing guard and insert logic unchanged → `SaveChangesAsync` → `CommitAsync`

## Verification

.NET SDK is not available in the remote execution environment; build and test could not be run locally.

Code correctness verified by inspection:
- Transaction scope covers both the count read and the insert, making the check-then-act atomic under serializable isolation
- `await using var tx` guarantees rollback on early return (`LimitReached`) or exception
- `CommitAsync` is called only after `SaveChangesAsync` succeeds

## Remaining Risks / Assumptions

- A serialization conflict returns HTTP 500 instead of a user-friendly error. A future improvement could catch `NpgsqlException { SqlState = "40001" }` and return `AddressErrors.LimitReached` (HTTP 409).
- No DB-level constraint (unique partial index or check constraint) is added; that remains the recommended long-term defence but requires a migration outside the scope of this automated fix.

https://claude.ai/code/session_01LQNkxgJtAj3kGfVjowHVwa

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQNkxgJtAj3kGfVjowHVwa)_