### PR TITLE
Fix #105: Replace .First() with dictionary lookup in BulkUpdateVariantsAsync

### DIFF
--- a/src/VendlyServer.Application/Services/Products/ProductService.cs
+++ b/src/VendlyServer.Application/Services/Products/ProductService.cs
@@ -393,9 +393,11 @@ public class ProductService(
         if (variants.Count != requestedIds.Count)
             return ProductErrors.VariantNotFound;
 
+        var variantById = variants.ToDictionary(v => v.Id);
+
         foreach (var item in request.Variants)
         {
-            var variant = variants.First(v => v.Id == item.Id);
+            var variant = variantById[item.Id];
             variant.Name = item.Name;
             variant.Price = item.Price;
             variant.Quantity = item.Quantity;


### PR DESCRIPTION
Fixes #105

## Summary

- Replaced the forbidden `.First()` LINQ call in `BulkUpdateVariantsAsync` with a `ToDictionary` lookup, in compliance with the project's coding standard that prohibits `.First()`.
- Builds a `Dictionary<long, ProductVariant>` once before the loop (O(n)), then uses the indexer `variantById[item.Id]` per iteration (O(1)), eliminating the O(n²) linear scan.
- Semantically equivalent to the original: the pre-existing guard (`variants.Count != requestedIds.Count`) guarantees every requested ID is present, so `variantById[item.Id]` will never throw `KeyNotFoundException`.

## Files Changed

- `src/VendlyServer.Application/Services/Products/ProductService.cs` — `BulkUpdateVariantsAsync` method

## Verification

The .NET 10 SDK is not installed in this execution environment, so `dotnet build` / `dotnet test` could not be run directly. The change is a two-line syntactic substitution:

1. Added `var variantById = variants.ToDictionary(v => v.Id);` (standard LINQ, no new dependency)
2. Replaced `variants.First(v => v.Id == item.Id)` with `variantById[item.Id]`

Existing tests in `tests/VendlyServer.Tests/Services/ProductServiceTests.cs` cover `BulkUpdateVariantsAsync` (happy path, product-not-found, variant-not-found, cross-product variant guard) and will validate the fix on CI.

## Remaining Risks / Assumptions

- None for finding 2 (this PR). 
- Finding 1 from the same issue (`ToLower()` causing full-table scans in `SearchAsync`) is **not addressed here** — it requires adding PostgreSQL functional or trigram indexes via a migration and is a separate, larger change.

https://claude.ai/code/session_01H14tLpjq7oAsxGYxvhovcy

---
_Generated by [Claude Code](https://claude.ai/code/session_01H14tLpjq7oAsxGYxvhovcy)_