### PR TITLE
Fix #106: eliminate N+1 SaveChangesAsync calls in RegenerateVariantsAsync

### DIFF
--- a/src/VendlyServer.Application/Services/Products/ProductService.cs
+++ b/src/VendlyServer.Application/Services/Products/ProductService.cs
@@ -354,20 +354,14 @@ public class ProductService(
                 Price = 0,
                 Quantity = 0,
                 IsActive = true,
-                Images = new List<string>()
+                Images = new List<string>(),
+                OptionValues = combo.Select(opt => new VariantOptionValue
+                {
+                    VariantOptionId = opt.Id
+                }).ToList()
             };
 
             dbContext.ProductVariants.Add(newVariant);
-            await dbContext.SaveChangesAsync(ct);
-
-            foreach (var opt in combo)
-            {
-                dbContext.VariantOptionValues.Add(new VariantOptionValue
-                {
-                    ProductVariantId = newVariant.Id,
-                    VariantOptionId = opt.Id
-                });
-            }
         }
 
         foreach (var v in existingVariants.Where(v => !usedVariantIds.Contains(v.Id)))


### PR DESCRIPTION
Fixes #106

## Summary

`RegenerateVariantsAsync` was calling `SaveChangesAsync` inside the variant-combination loop to obtain the EF-generated `ProductVariant.Id` before creating `VariantOptionValue` rows. For a product with many options (e.g. 3 types × 4 options = 64 combinations) this caused 64 separate database round-trips + 64 implicit transactions on the `product_variants` table.

The fix assigns `OptionValues` directly via the `ProductVariant.OptionValues` navigation property. EF Core resolves the FK (`ProductVariantId`) automatically when the entity graph is saved, collapsing all inserts into a single batched transaction at the end of the method.

**Before:**
```csharp
dbContext.ProductVariants.Add(newVariant);
await dbContext.SaveChangesAsync(ct);           // ← 1 round-trip per new variant
foreach (var opt in combo)
{
    dbContext.VariantOptionValues.Add(new VariantOptionValue
    {
        ProductVariantId = newVariant.Id,        // ← required the early save
        VariantOptionId  = opt.Id
    });
}
```

**After:**
```csharp
var newVariant = new ProductVariant
{
    ...
    OptionValues = combo.Select(opt => new VariantOptionValue
    {
        VariantOptionId = opt.Id
    }).ToList()   // EF Core fills ProductVariantId during the graph insert
};
dbContext.ProductVariants.Add(newVariant);
// SaveChangesAsync called once, outside the loop
```

## Files changed

- `src/VendlyServer.Application/Services/Products/ProductService.cs`

## Verification

`dotnet` is not installed in the automated fix environment; local compilation could not be run. The change relies solely on EF Core's standard entity-graph behaviour (`ProductVariant.OptionValues` is declared as `ICollection<VariantOptionValue>` with a proper FK back-reference), which is well-tested. CI build should serve as the verification gate.

## Remaining risks / assumptions

- Assumes the EF Core relationship between `ProductVariant` and `VariantOptionValue` is correctly configured (confirmed: `[ForeignKey(nameof(ProductVariantId))]` is present on `VariantOptionValue.ProductVariant`).
- The final `SaveChangesAsync` already saves soft-deletes for removed variants in the same call, so there is no change in transactional scope — the previous code also had a trailing save.

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZqjUE6qkFqKFT8EwHHsad)_