### PR TITLE
Fix #120: cap DataQueryRequest.PageSize at 100 to prevent unbounded DB scans

### DIFF
--- a/src/VendlyServer.Domain/Abstractions/DataQueryRequest.cs
+++ b/src/VendlyServer.Domain/Abstractions/DataQueryRequest.cs
@@ -3,7 +3,14 @@ namespace VendlyServer.Domain.Abstractions;
 public record DataQueryRequest
 {
     public int Page { get; set; } = 1;
-    public int PageSize { get; set; } = 20;
+
+    private int _pageSize = 20;
+    public int PageSize
+    {
+        get => _pageSize;
+        set => _pageSize = Math.Clamp(value, 1, 100);
+    }
+
     public string? SortBy { get; set; }
     public SortDirection SortDirection { get; set; } = SortDirection.Asc;
 }


### PR DESCRIPTION
Fixes #120

## Summary

`DataQueryRequest.PageSize` had no server-side cap, allowing any caller to send `?pageSize=1000000` and trigger a full-table scan on any endpoint that uses `DataQueryRequest`. This is especially risky on `GET /api/admin/sync-logs` given the open VER-35 finding (any authenticated user can reach admin endpoints).

The fix replaces the auto-property with a computed property backed by a private field, clamping `PageSize` to the range `[1, 100]` using `Math.Clamp`. The default (20) is preserved.

## Files Changed

- `src/VendlyServer.Domain/Abstractions/DataQueryRequest.cs` — added `Math.Clamp(value, 1, 100)` setter

## Verification

The dotnet SDK was not available in the execution environment, so a local build could not be run. The change is syntactically valid C# — a standard computed property with a backing field in a `record` type with `ImplicitUsings` enabled (so `System.Math` is in scope). The pattern is identical to the recommended fix in the issue body.

## Risks and Assumptions

- The cap of 100 is a reasonable default; per-endpoint tuning can be done if specific endpoints need a higher bound.
- Any `DataQueryRequest with { PageSize = N }` copy expressions will apply the clamp through the setter.
- Existing callers sending `pageSize <= 100` are unaffected.
- This does not address the VER-35 authorization gap (open separately).

---
_Generated by [Claude Code](https://claude.ai/code/session_013fC327jZQM3DLB89NVB529)_