### PR TITLE
Fix #125: replace ContinueWith with await and cap PageSize

### DIFF
--- a/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
+++ b/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
@@ -147,12 +147,13 @@ public class SmartupSyncService(
         logger.LogInformation("Smartup Sync [{LogId}]: categories — +{Created} ~{Updated}",
             logId, created, updated);
 
-        var idMap = await dbContext.Categories
+        var allCategories = await dbContext.Categories
             .Where(c => !c.IsDeleted && c.Metadata != null)
-            .ToListAsync(cancellationToken)
-            .ContinueWith(t => t.Result
-                .Where(c => TryGetSourceId(c.Metadata, out _))
-                .ToDictionary(c => GetSourceId(c.Metadata)!, c => c.Id));
+            .ToListAsync(cancellationToken);
+
+        var idMap = allCategories
+            .Where(c => TryGetSourceId(c.Metadata, out _))
+            .ToDictionary(c => GetSourceId(c.Metadata)!, c => c.Id);
 
         return (idMap, created, updated);
     }

--- a/src/VendlyServer.Domain/Abstractions/DataQueryRequest.cs
+++ b/src/VendlyServer.Domain/Abstractions/DataQueryRequest.cs
@@ -3,7 +3,14 @@ namespace VendlyServer.Domain.Abstractions;
 public record DataQueryRequest
 {
     public int Page { get; set; } = 1;
-    public int PageSize { get; set; } = 20;
+
+    private int _pageSize = 20;
+    public int PageSize
+    {
+        get => _pageSize;
+        set => _pageSize = Math.Clamp(value, 1, 100);
+    }
+
     public string? SortBy { get; set; }
     public SortDirection SortDirection { get; set; } = SortDirection.Asc;
 }


### PR DESCRIPTION
## Summary

Fixes #125 · Also resolves the identical finding in #120

Two correctness/safety fixes from the automated review dated 2026-05-24.

### Fix 1 — `SmartupSyncService.SyncCategoriesAsync`: replace `.ContinueWith()` with `await`

**File:** `src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs`

The chained `.ToListAsync(ct).ContinueWith(t => t.Result...)` pattern:
- Does not propagate the `CancellationToken` into the continuation.
- Accesses `t.Result` directly, which re-wraps a faulted task's exception in `AggregateException`, making it inconsistent with the rest of the async chain.

Split into two statements: `await ToListAsync(ct)` → in-memory LINQ, which is idiomatic, cancellation-safe, and exception-transparent.

### Fix 2 — `DataQueryRequest.PageSize`: clamp to `[1, 100]`

**File:** `src/VendlyServer.Domain/Abstractions/DataQueryRequest.cs`

`PageSize` had no upper bound, so any caller could pass `?pageSize=1000000` and trigger a full-table scan. Added a backing field with `Math.Clamp(value, 1, 100)`. Applies globally to every endpoint that uses `DataQueryRequest` (sync-logs, products, etc.).

## Files Changed

- `src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs`
- `src/VendlyServer.Domain/Abstractions/DataQueryRequest.cs`

## Verification

> **Note:** `dotnet` is not installed in this automated execution environment, so the build could not be run locally. The changes are syntactically straightforward — a two-statement await split and a standard backing-field Math.Clamp pattern — and carry no logic risk. CI should confirm the build.

## Risks / Assumptions

- The `PageSize` cap of 100 matches the value recommended in the issue. If any existing UI or integration test sends `pageSize > 100`, it will silently receive at most 100 items. No breaking change for normal usage.
- The `allCategories` variable name introduced in `SyncCategoriesAsync` is local and does not conflict with anything.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BkyDahGJb6d7k6KSaySxjb)_