### PR TITLE
Fix #105: replace .First() with dictionary lookup in BulkUpdateVariantsAsync

### DIFF
--- a/src/VendlyServer.Application/Services/Products/ProductService.cs
+++ b/src/VendlyServer.Application/Services/Products/ProductService.cs
@@ -393,9 +393,11 @@ public class ProductService(
         if (variants.Count != requestedIds.Count)
             return ProductErrors.VariantNotFound;
 
+        var variantById = variants.ToDictionary(v => v.Id);
+
         foreach (var item in request.Variants)
         {
-            var variant = variants.First(v => v.Id == item.Id);
+            if (!variantById.TryGetValue(item.Id, out var variant)) continue;
             variant.Name = item.Name;
             variant.Price = item.Price;
             variant.Quantity = item.Quantity;


### PR DESCRIPTION
## Summary

Fixes #105 (Warning 2 — `.First()` violation in `ProductService.BulkUpdateVariantsAsync`)

The project coding standard (`best-practices.md`) explicitly prohibits `.First()` in favour of `.SingleOrDefault()` / dictionary lookups, because `.First()` silently returns the wrong record when duplicate IDs exist and produces an unhelpful `InvalidOperationException` on an empty sequence.

### Change

**File:** `src/VendlyServer.Application/Services/Products/ProductService.cs`

Before the loop, build a `Dictionary<long, ProductVariant>` from the already-loaded `variants` list. Inside the loop, use `TryGetValue` instead of `.First(...)`. This:

- Eliminates the `.First()` violation.
- Changes the lookup from O(n) linear scan to O(1).
- Makes intent explicit: if a variant ID is somehow missing despite the count guard, the `continue` makes the defensive behaviour visible rather than throwing.

## Files Changed

- `src/VendlyServer.Application/Services/Products/ProductService.cs`

## Verification

> **Note:** `dotnet` is not installed in this automated execution environment. The change is a mechanical substitution of a `.First()` call with a `ToDictionary` + `TryGetValue` pattern — no logic was altered. CI build should confirm.

## Risks / Assumptions

- The pre-existing guard `if (variants.Count != requestedIds.Count) return ProductErrors.VariantNotFound` ensures the dictionary is fully populated before the loop, so the `continue` branch is effectively dead code under normal conditions — it simply makes the fallback safe.
- No other callers are affected; the change is local to `BulkUpdateVariantsAsync`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BkyDahGJb6d7k6KSaySxjb)_