### PR TITLE
Fix #125: Replace ContinueWith with await and cap DataQueryRequest.PageSize

### DIFF
--- a/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
+++ b/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
@@ -147,12 +147,13 @@ public class SmartupSyncService(
         logger.LogInformation("Smartup Sync [{LogId}]: categories — +{Created} ~{Updated}",
             logId, created, updated);
 
-        var idMap = await dbContext.Categories
+        var allCategories = await dbContext.Categories
             .Where(c => !c.IsDeleted && c.Metadata != null)
-            .ToListAsync(cancellationToken)
-            .ContinueWith(t => t.Result
-                .Where(c => TryGetSourceId(c.Metadata, out _))
-                .ToDictionary(c => GetSourceId(c.Metadata)!, c => c.Id));
+            .ToListAsync(cancellationToken);
+
+        var idMap = allCategories
+            .Where(c => TryGetSourceId(c.Metadata, out _))
+            .ToDictionary(c => GetSourceId(c.Metadata)!, c => c.Id);
 
         return (idMap, created, updated);
     }

--- a/src/VendlyServer.Domain/Abstractions/DataQueryRequest.cs
+++ b/src/VendlyServer.Domain/Abstractions/DataQueryRequest.cs
@@ -3,7 +3,14 @@ namespace VendlyServer.Domain.Abstractions;
 public record DataQueryRequest
 {
     public int Page { get; set; } = 1;
-    public int PageSize { get; set; } = 20;
+
+    private int _pageSize = 20;
+    public int PageSize
+    {
+        get => _pageSize;
+        set => _pageSize = Math.Clamp(value, 1, 100);
+    }
+
     public string? SortBy { get; set; }
     public SortDirection SortDirection { get; set; } = SortDirection.Asc;
 }


### PR DESCRIPTION
## Summary

- Fixes #125 — Warning 1 (`ContinueWith` in `SyncCategoriesAsync`) and Warning 3 (unbounded `PageSize`)
- Also fixes #120 — same unbounded `PageSize` root cause

## Changes

### 1. `SmartupSyncService.SyncCategoriesAsync` — replace `.ContinueWith()` with `await`

The old code called `.ContinueWith(t => t.Result ...)` on the `ToListAsync` task:
- Accesses `t.Result` directly, which re-wraps a faulted task's exception in `AggregateException`, making it harder to catch and log correctly
- Does not propagate the original `CancellationToken` to the continuation
- Does not respect `SynchronizationContext`

Replaced with a two-step await: `await ToListAsync(...)` then inline LINQ `.ToDictionary(...)`.

### 2. `DataQueryRequest.PageSize` — clamp to `[1, 100]`

Added `Math.Clamp(value, 1, 100)` in the setter so no caller can trigger an unbounded full-table read by supplying an arbitrary page size value. Default remains 20.

## Files Changed

- `src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs`
- `src/VendlyServer.Domain/Abstractions/DataQueryRequest.cs`

## Verification

Build and test commands (requires dotnet SDK in environment):
```
dotnet build
dotnet test
```

Note: dotnet SDK was not available in the automated fix environment. The changes are minimal and syntactically straightforward C# — both are single-method or single-property edits with no logic branching added.

## Risks / Assumptions

- The `PageSize` cap of 100 matches the recommendation in both #120 and #125. If a specific endpoint legitimately needs a higher cap, that endpoint's service can apply its own override.
- The `ContinueWith` → `await` refactor is semantically equivalent: the dictionary is built from the same data, with proper cancellation and exception propagation restored.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ft1y5cEd8Mc5GwDqC93jVu)_