### PR TITLE
Fix #105: Replace .First() with dictionary lookup in BulkUpdateVariantsAsync

### DIFF
--- a/src/VendlyServer.Application/Services/Products/ProductService.cs
+++ b/src/VendlyServer.Application/Services/Products/ProductService.cs
@@ -393,9 +393,11 @@ public class ProductService(
         if (variants.Count != requestedIds.Count)
             return ProductErrors.VariantNotFound;
 
+        var variantById = variants.ToDictionary(v => v.Id);
+
         foreach (var item in request.Variants)
         {
-            var variant = variants.First(v => v.Id == item.Id);
+            var variant = variantById[item.Id];
             variant.Name = item.Name;
             variant.Price = item.Price;
             variant.Quantity = item.Quantity;


### PR DESCRIPTION
## Summary

Fixes #105 — Warning 2: `.First()` used in `ProductService.BulkUpdateVariantsAsync`, violating the project's coding standard documented in `.claude/rules/server-side/best-practices.md`.

## Root Cause

```csharp
var variant = variants.First(v => v.Id == item.Id);
```

- `.First()` is explicitly forbidden by project standards in favour of `.SingleOrDefault()` or dictionary lookups
- If the `variants` list ever contains duplicate IDs (e.g. a data integrity regression), `.First()` silently returns the wrong record instead of surfacing the problem
- The maintenance risk: future contributors removing or reordering the `count != requestedIds.Count` guard above would leave a latent crash

## Fix

Pre-build a dictionary before the loop:

```csharp
var variantById = variants.ToDictionary(v => v.Id);

foreach (var item in request.Variants)
{
    var variant = variantById[item.Id];
    ...
}
```

The O(1) dictionary indexer replaces the O(n) `.First()` search on every iteration, and will throw `KeyNotFoundException` on a missing ID — making data integrity violations explicit rather than silent.

The count-guard (`variants.Count != requestedIds.Count → return ProductErrors.VariantNotFound`) immediately above still guarantees all requested IDs are present, so the indexer will not throw under normal operation.

## Files Changed

- `src/VendlyServer.Application/Services/Products/ProductService.cs`

## Verification

```
dotnet build
dotnet test
```

Note: dotnet SDK was not available in the automated fix environment. The change is a one-line mechanical replacement with no logic branching.

## Risks / Assumptions

No behavioural change under correct data. Under data integrity failures (duplicate variant IDs), the old code would silently update the wrong variant; the new code surfaces the problem explicitly via `KeyNotFoundException`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ft1y5cEd8Mc5GwDqC93jVu)_