### PR TITLE
Fix #120: Cap DataQueryRequest.PageSize to prevent unbounded table scans

### DIFF
--- a/src/VendlyServer.Domain/Abstractions/DataQueryRequest.cs
+++ b/src/VendlyServer.Domain/Abstractions/DataQueryRequest.cs
@@ -3,7 +3,14 @@ namespace VendlyServer.Domain.Abstractions;
 public record DataQueryRequest
 {
     public int Page { get; set; } = 1;
-    public int PageSize { get; set; } = 20;
+
+    private int _pageSize = 20;
+    public int PageSize
+    {
+        get => _pageSize;
+        set => _pageSize = Math.Clamp(value, 1, 100);
+    }
+
     public string? SortBy { get; set; }
     public SortDirection SortDirection { get; set; } = SortDirection.Asc;
 }


### PR DESCRIPTION
## Summary

Fixes #120

Without a server-side cap on `PageSize`, any caller can pass an arbitrarily large value (e.g. `?pageSize=1000000`) and trigger a full-table scan returning the entire result set in a single response. This is a potential DoS vector against the database, amplified by the currently open VER-35 finding that any authenticated Customer-role user can reach admin endpoints.

## Fix

Added a clamped `PageSize` property to `DataQueryRequest` that silently caps the value between 1 and 100:

```csharp
private int _pageSize = 20;
public int PageSize
{
    get => _pageSize;
    set => _pageSize = Math.Clamp(value, 1, 100);
}
```

This applies to every endpoint that uses `DataQueryRequest` as a query parameter, including `GET /api/admin/sync-logs` and any other paginated endpoints.

Note: this also resolves Warning 3 from issue #125.

## Files Changed

- `src/VendlyServer.Domain/Abstractions/DataQueryRequest.cs`

## Verification

No dotnet runtime available in this environment — build and test verification cannot be run. The change is confined to a single property setter with no dependencies or migration required.

## Risks / Assumptions

- Existing callers that relied on a `PageSize` above 100 will silently receive at most 100 results. This is the intended behavior.
- The cap of 100 can be adjusted per endpoint if needed by introducing endpoint-specific query models.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKxPsTBpryS8w6TM1tUXAV)_