### PR TITLE
Fix #125: Replace ContinueWith with await in SyncCategoriesAsync

### DIFF
--- a/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
+++ b/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
@@ -147,12 +147,13 @@ public class SmartupSyncService(
         logger.LogInformation("Smartup Sync [{LogId}]: categories — +{Created} ~{Updated}",
             logId, created, updated);
 
-        var idMap = await dbContext.Categories
+        var all = await dbContext.Categories
             .Where(c => !c.IsDeleted && c.Metadata != null)
-            .ToListAsync(cancellationToken)
-            .ContinueWith(t => t.Result
-                .Where(c => TryGetSourceId(c.Metadata, out _))
-                .ToDictionary(c => GetSourceId(c.Metadata)!, c => c.Id));
+            .ToListAsync(cancellationToken);
+
+        var idMap = all
+            .Where(c => TryGetSourceId(c.Metadata, out _))
+            .ToDictionary(c => GetSourceId(c.Metadata)!, c => c.Id);
 
         return (idMap, created, updated);
     }


### PR DESCRIPTION
## Summary

Fixes #125 (Warning 1)

`SyncCategoriesAsync` used `.ContinueWith(t => t.Result ...)` to transform the result of `ToListAsync`. This pattern has three problems:

1. **CancellationToken not propagated** — `ContinueWith` runs a new task that ignores the original `CancellationToken`, so cancellation stops `ToListAsync` but the continuation still runs.
2. **AggregateException wrapping** — accessing `t.Result` on a faulted task re-wraps the original exception in `AggregateException`, making it harder to catch and inconsistent with the rest of the async chain.
3. **SynchronizationContext ignored** — `ContinueWith` does not capture the current `SynchronizationContext`, differing from `await` behaviour.

## Fix

Split into a standard `await` call followed by an in-memory LINQ chain:

```csharp
var all = await dbContext.Categories
    .Where(c => !c.IsDeleted && c.Metadata != null)
    .ToListAsync(cancellationToken);

var idMap = all
    .Where(c => TryGetSourceId(c.Metadata, out _))
    .ToDictionary(c => GetSourceId(c.Metadata)!, c => c.Id);
```

## Files Changed

- `src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs`

## Verification

No dotnet runtime available in this environment — build and test verification cannot be run. The change is a mechanical rewrite of an async continuation to an equivalent `await` pattern with no logic change.

## Risks / Assumptions

None. The observable behaviour is identical; only exception propagation and cancellation handling are corrected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKxPsTBpryS8w6TM1tUXAV)_