### PR TITLE
Fix #105: Replace .First() with .SingleOrDefault() in BulkUpdateVariantsAsync

### DIFF
--- a/src/VendlyServer.Application/Services/Products/ProductService.cs
+++ b/src/VendlyServer.Application/Services/Products/ProductService.cs
@@ -395,7 +395,7 @@ public class ProductService(
 
         foreach (var item in request.Variants)
         {
-            var variant = variants.First(v => v.Id == item.Id);
+            var variant = variants.SingleOrDefault(v => v.Id == item.Id)!;
             variant.Name = item.Name;
             variant.Price = item.Price;
             variant.Quantity = item.Quantity;


### PR DESCRIPTION
## Summary

Fixes #105 (Warning 2)

`ProductService.BulkUpdateVariantsAsync` used `.First()` to look up a variant by ID from an in-memory list, directly violating the project coding standard which prohibits `.First()` and requires `.SingleOrDefault()` (or `.SingleOrDefaultAsync()` for EF queries).

## Fix

```csharp
// Before
var variant = variants.First(v => v.Id == item.Id);

// After
var variant = variants.SingleOrDefault(v => v.Id == item.Id)!;
```

The null-forgiving `!` is safe because the preceding guard already verifies that every requested ID exists in the loaded list (`variants.Count != requestedIds.Count` check at line 393).

## Files Changed

- `src/VendlyServer.Application/Services/Products/ProductService.cs`

## Verification

No dotnet runtime available in this environment — build and test verification cannot be run. The change is a single-line substitution with identical runtime behaviour given the existing guard.

## Risks / Assumptions

None. The existing count check guarantees the ID is always found, so `.SingleOrDefault()!` cannot return a dereferenced null in practice.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKxPsTBpryS8w6TM1tUXAV)_