### PR TITLE
Fix #135: clamp DataQueryRequest pagination params and log Smartup parse failures

### DIFF
--- a/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
+++ b/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
@@ -244,8 +244,20 @@ public class SmartupSyncService(
 
         foreach (var item in items)
         {
-            var price = decimal.TryParse(item.Price, out var p) ? p : 0m;
-            var quantity = int.TryParse(item.BalanceQuant, out var q) ? q : 0;
+            if (!decimal.TryParse(item.Price, System.Globalization.NumberStyles.Any,
+                    System.Globalization.CultureInfo.InvariantCulture, out var price))
+            {
+                logger.LogWarning("Smartup Sync: unparseable price '{Price}' for product {ProductId} — defaulting to 0",
+                    item.Price, item.ProductId);
+                price = 0m;
+            }
+
+            if (!int.TryParse(item.BalanceQuant, out var quantity))
+            {
+                logger.LogWarning("Smartup Sync: unparseable quantity '{Quant}' for product {ProductId} — defaulting to 0",
+                    item.BalanceQuant, item.ProductId);
+                quantity = 0;
+            }
             var images = new List<string>();
             foreach (var sha in item.PhotoSha)
             {

--- a/src/VendlyServer.Domain/Abstractions/DataQueryRequest.cs
+++ b/src/VendlyServer.Domain/Abstractions/DataQueryRequest.cs
@@ -2,8 +2,20 @@ namespace VendlyServer.Domain.Abstractions;
 
 public record DataQueryRequest
 {
-    public int Page { get; set; } = 1;
-    public int PageSize { get; set; } = 20;
+    private int _page = 1;
+    public int Page
+    {
+        get => _page;
+        set => _page = Math.Clamp(value, 1, int.MaxValue);
+    }
+
+    private int _pageSize = 20;
+    public int PageSize
+    {
+        get => _pageSize;
+        set => _pageSize = Math.Clamp(value, 1, 100);
+    }
+
     public string? SortBy { get; set; }
     public SortDirection SortDirection { get; set; } = SortDirection.Asc;
 }


### PR DESCRIPTION
Fixes #135

## Summary

- **Finding 1 — `DataQueryRequest.Page` unclamped**: Passing `?page=0` or `?page=-1` to any paginated endpoint caused EF Core to receive a negative `Skip` argument, resulting in an `ArgumentOutOfRangeException` and HTTP 500 on all paginated routes. Additionally, `PageSize` had no server-side cap, allowing arbitrarily large result sets. Both properties now use `Math.Clamp`: `Page` is bounded to `[1, int.MaxValue]`, `PageSize` to `[1, 100]`.

- **Finding 2 — Silent Smartup price/quantity parse failures**: When the Smartup API returned a non-numeric value for `Price` or `BalanceQuant`, `decimal.TryParse` / `int.TryParse` silently fell back to `0`, causing products to appear free or out-of-stock on the storefront with no indication in sync logs. Parse failures now emit `LogWarning` with the raw value and product ID so they surface during operational review.

## Files Changed

- `src/VendlyServer.Domain/Abstractions/DataQueryRequest.cs` — backing-field properties with `Math.Clamp` for `Page` and `PageSize`
- `src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs` — explicit `LogWarning` on price and quantity parse failures in `UpsertProductsAsync`

## Verification

- `dotnet build` — not executable in this container (dotnet not installed); changes are syntactically standard C# with no new dependencies
- Changes are purely defensive (clamping + logging); no behavioral changes under valid inputs

## Risks / Assumptions

- Clients sending `page < 1` or `pageSize > 100` will silently have their values clamped rather than receiving a 400 error. This is consistent with the clamping approach shown in issue #135's recommended fix. If strict validation with a 400 response is preferred, add `[Range]` annotations and enable `ModelValidationFilter` instead.
- `decimal.TryParse` now uses `NumberStyles.Any` + `InvariantCulture` which is more permissive than the original bare `TryParse` (handles locale-formatted strings like `"1 500.00"`). This is intentional — the change reduces false-negative parse failures from differently-formatted Smartup responses.

---
_Generated by [Claude Code](https://claude.ai/code/session_019meenbBK5yGfYFq3pY6Fcq)_