### PR TITLE
Fix #139: log unexpected exceptions in MinioStorageService.ExistsAsync

### DIFF
--- a/src/VendlyServer.Application/Services/Storages/MinioStorageService.cs
+++ b/src/VendlyServer.Application/Services/Storages/MinioStorageService.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Minio;
 using Minio.DataModel.Args;
@@ -8,7 +9,8 @@ namespace VendlyServer.Application.Services.Storages;
 public class MinioStorageService(
     IMinioClient minioClient,
     IOptions<MinioOptions> minioOptions,
-    IOptions<StorageOptions> storageOptions) : IStorageService
+    IOptions<StorageOptions> storageOptions,
+    ILogger<MinioStorageService> logger) : IStorageService
 {
     private readonly MinioOptions _minio = minioOptions.Value;
     private readonly StorageOptions _storage = storageOptions.Value;
@@ -98,8 +100,13 @@ public class MinioStorageService(
         {
             return false;
         }
-        catch
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "MinIO StatObject for {ObjectKey} threw an unexpected exception; treating as non-existent", objectKey);
             return false;
         }
     }


### PR DESCRIPTION
$(cat <<'EOF'
Fixes #139 (Finding 1)

## Summary

`MinioStorageService.ExistsAsync` had a bare `catch` block that silently returned `false` for every exception other than `ObjectNotFoundException`. This meant:

- Network errors, auth failures, and timeouts were swallowed with no log entry
- When MinIO was temporarily unavailable, every `ExistsAsync` call returned `false`, causing `SmartupSyncService.ResolveImageUrlAsync` to re-download every product image from Smartup on every sync run
- The actual root cause (MinIO down) was invisible in logs

## Fix

Replaced the bare `catch` with:
1. An explicit `OperationCanceledException` guard to propagate cancellation correctly (consistent with the same pattern used in `UploadAsync` and `DeleteAsync`)
2. A `catch (Exception ex)` block that logs a `LogWarning` with the object key and full exception, so unexpected MinIO failures surface in sync logs

Added `ILogger<MinioStorageService>` to the constructor (injected via DI).

## Files Changed

- `src/VendlyServer.Application/Services/Storages/MinioStorageService.cs`

## Verification

The `dotnet` SDK is not installed in this execution environment. The change is:
- A one-line constructor parameter addition (`ILogger<MinioStorageService> logger`)
- Replacement of `catch { return false; }` with three explicit catch clauses (standard C# pattern)
- No new package dependencies — `Microsoft.Extensions.Logging` is already used throughout Application

## Risks / Assumptions

- Behaviour under `ObjectNotFoundException` (cache miss) is unchanged — returns `false` as before
- Behaviour under cancellation now correctly rethrows instead of silently returning `false`
- Behaviour under other exceptions is unchanged in terms of return value (`false` is still returned); the only addition is a `LogWarning` call, making the failure observable without changing the sync flow

---
_Generated by [Claude Code](https://claude.ai/code/session_01JirefmERYrh2E6ovN2T1Gt)_
EOF
)