### PR TITLE
Fix #142: deactivate products removed from Smartup catalog

### DIFF
--- a/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
+++ b/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
@@ -182,6 +182,8 @@ public class SmartupSyncService(
             var catCreated = 0;
             var catUpdated = 0;
             var catErrors = 0;
+            var allReturnedIds = new HashSet<string>();
+            var allPagesFetched = true;
 
             do
             {
@@ -194,11 +196,15 @@ public class SmartupSyncService(
                         logId, cat.ProductTypeId, page, call.Result.Error.Code);
                     catErrors++;
                     totalErrors++;
+                    allPagesFetched = false;
                     break;
                 }
 
                 var envelope = call.Result.Data!;
                 pageCount = envelope.GetPageCount();
+
+                foreach (var item in envelope.Products)
+                    allReturnedIds.Add(item.ProductId);
 
                 var (c, u) = await UpsertProductsAsync(envelope.Products, categoryId, cancellationToken);
                 catCreated += c;
@@ -209,6 +215,9 @@ public class SmartupSyncService(
                 page++;
             }
             while (page <= pageCount);
+
+            if (allPagesFetched)
+                await DeactivateMissingProductsAsync(categoryId, allReturnedIds, cancellationToken);
 
             logger.LogInformation(
                 "Smartup Sync [{LogId}]: [{CategoryName}] — +{Created} ~{Updated} !{Errors}",
@@ -306,6 +315,32 @@ public class SmartupSyncService(
 
         await dbContext.SaveChangesAsync(cancellationToken);
         return (created, updated);
+    }
+
+    private async Task DeactivateMissingProductsAsync(
+        long categoryId, HashSet<string> returnedIds, CancellationToken cancellationToken)
+    {
+        var dbProducts = await dbContext.Products
+            .Where(p => !p.IsDeleted && p.CategoryId == categoryId && p.SyncSource == SyncSource.External && p.IsActive)
+            .Include(p => p.Variants)
+            .ToListAsync(cancellationToken);
+
+        var anyDeactivated = false;
+        foreach (var product in dbProducts)
+        {
+            if (!TryGetSourceId(product.Metadata, out var sourceId) || sourceId is null)
+                continue;
+            if (returnedIds.Contains(sourceId))
+                continue;
+
+            product.IsActive = false;
+            foreach (var variant in product.Variants.Where(v => !v.IsDeleted))
+                variant.IsActive = false;
+            anyDeactivated = true;
+        }
+
+        if (anyDeactivated)
+            await dbContext.SaveChangesAsync(cancellationToken);
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #142

`UpsertProductsAsync` upserted products returned by Smartup but never touched products that existed locally but were absent from the API response. Over time, products discontinued by the supplier accumulated as permanently active/purchasable phantom items.

- Accumulates all returned `ProductId` values across **all pages** of each category into a `HashSet<string>` during the existing page loop.
- After the loop, calls a new `DeactivateMissingProductsAsync` method that sets `IsActive = false` on any locally-active external product whose source ID is absent from that set, along with its non-deleted variants.
- Deactivation is intentionally **skipped when any page fetch fails** (`allPagesFetched = false`) to prevent incorrectly deactivating products due to a partial response.

## Files changed

- `src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs`
  - `SyncProductsAsync`: added `allReturnedIds` HashSet and `allPagesFetched` flag; calls `DeactivateMissingProductsAsync` after the page loop when all pages fetched successfully.
  - New private method `DeactivateMissingProductsAsync`: queries active external products in the category, deactivates those absent from `returnedIds`, saves if any were changed.

## Verification

No .NET SDK available in the remote execution environment; build could not be run locally. The change follows the exact same EF Core query and save patterns used throughout the service. Logic reviewed manually.

## Risks / assumptions

- Assumes Smartup returns a complete product list per category across all pages. If Smartup ever returns a partial page response without signalling an error, products could be incorrectly deactivated — but this is the same assumption the rest of the sync makes.
- Products with `SyncSource != External` are not touched.
- Products with no parseable `source_id` in their metadata are skipped (unchanged behaviour).


---
_Generated by [Claude Code](https://claude.ai/code/session_011AoFXur6Jhg6w2tmHhTS1j)_