### PR TITLE
Fix #143: validate SmartupOptions required fields at startup

### DIFF
--- a/src/VendlyServer.Infrastructure/Brokers/Smartup/SmartupOptions.cs
+++ b/src/VendlyServer.Infrastructure/Brokers/Smartup/SmartupOptions.cs
@@ -1,12 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace VendlyServer.Infrastructure.Brokers.Smartup;
 
 public class SmartupOptions
 {
     public const string SectionName = "Smartup";
 
+    [Required, Url]
     public string BaseUrl { get; set; } = string.Empty;
+
+    [Required, Url]
     public string ImageBaseUrl { get; set; } = string.Empty;
+
+    [Required]
     public string Token { get; set; } = string.Empty;
+
+    [Required]
     public string PersonId { get; set; } = string.Empty;
+
+    [Required]
     public string FilialId { get; set; } = string.Empty;
 }

--- a/src/VendlyServer.Infrastructure/Dependencies.cs
+++ b/src/VendlyServer.Infrastructure/Dependencies.cs
@@ -67,6 +67,9 @@ public static class Dependencies
     private static IServiceCollection ConfigureSmartup(this IServiceCollection services)
     {
         services.ConfigureOptions<SmartupOptionsSetup>();
+        services.AddOptions<SmartupOptions>()
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
         services.AddHttpClient("Smartup");
         services.AddSingleton<ISmartupBroker, SmartupBroker>();
 


### PR DESCRIPTION
## Summary

Fixes #143

`SmartupOptions` had no field validation: missing or empty `Token`, `BaseUrl`, `PersonId`, or `FilialId` were only discovered when the nightly Hangfire sync job ran, surfacing as opaque HTTP errors with no startup signal.

- Added `[Required]` annotations to all five fields and `[Url]` to `BaseUrl` and `ImageBaseUrl` so misconfigured or absent values produce a clear validation message.
- Registered `.ValidateDataAnnotations().ValidateOnStart()` in `ConfigureSmartup` so the application fails fast at startup if the `Smartup` config section is missing or incomplete, rather than silently failing up to 24 hours later.

## Files changed

- `src/VendlyServer.Infrastructure/Brokers/Smartup/SmartupOptions.cs` — added `using System.ComponentModel.DataAnnotations` and `[Required]` / `[Url]` attributes.
- `src/VendlyServer.Infrastructure/Dependencies.cs` — `ConfigureSmartup`: added `services.AddOptions<SmartupOptions>().ValidateDataAnnotations().ValidateOnStart()` alongside the existing `ConfigureOptions<SmartupOptionsSetup>()` binding.

## Verification

No .NET SDK available in the remote execution environment; build could not be run locally. The pattern mirrors standard ASP.NET Core options validation; `AddOptions<T>().ValidateDataAnnotations().ValidateOnStart()` is a well-known DI idiom that composes cleanly with the existing `IConfigureOptions<T>` binding.

## Risks / assumptions

- If an existing deployment has an incomplete `appsettings` (e.g. `Token` left empty), the app will now refuse to start. This is the intended behaviour, but operators must ensure all required fields are set before deploying.
- `[Url]` validates that `BaseUrl` and `ImageBaseUrl` are absolute HTTP/HTTPS URLs; values like bare hostnames without a scheme will fail validation.


---
_Generated by [Claude Code](https://claude.ai/code/session_011AoFXur6Jhg6w2tmHhTS1j)_