### PR TITLE
Fix #142: Deactivate Smartup products absent from API response

### DIFF
--- a/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
+++ b/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
@@ -182,6 +182,7 @@ public class SmartupSyncService(
             var catCreated = 0;
             var catUpdated = 0;
             var catErrors = 0;
+            var returnedProductIds = new HashSet<string>();
 
             do
             {
@@ -200,6 +201,9 @@ public class SmartupSyncService(
                 var envelope = call.Result.Data!;
                 pageCount = envelope.GetPageCount();
 
+                foreach (var item in envelope.Products)
+                    returnedProductIds.Add(item.ProductId);
+
                 var (c, u) = await UpsertProductsAsync(envelope.Products, categoryId, cancellationToken);
                 catCreated += c;
                 catUpdated += u;
@@ -209,6 +213,9 @@ public class SmartupSyncService(
                 page++;
             }
             while (page <= pageCount);
+
+            if (catErrors == 0)
+                await DeactivateMissingProductsAsync(categoryId, returnedProductIds, cancellationToken);
 
             logger.LogInformation(
                 "Smartup Sync [{LogId}]: [{CategoryName}] — +{Created} ~{Updated} !{Errors}",
@@ -306,6 +313,31 @@ public class SmartupSyncService(
 
         await dbContext.SaveChangesAsync(cancellationToken);
         return (created, updated);
+    }
+
+    private async Task DeactivateMissingProductsAsync(
+        long categoryId, HashSet<string> returnedIds, CancellationToken cancellationToken)
+    {
+        var dbProducts = await dbContext.Products
+            .Where(p => !p.IsDeleted && p.CategoryId == categoryId &&
+                        p.SyncSource == SyncSource.External && p.IsActive)
+            .Include(p => p.Variants)
+            .ToListAsync(cancellationToken);
+
+        var changed = false;
+        foreach (var product in dbProducts)
+        {
+            if (!TryGetSourceId(product.Metadata, out var sourceId) || returnedIds.Contains(sourceId!))
+                continue;
+
+            product.IsActive = false;
+            foreach (var variant in product.Variants.Where(v => !v.IsDeleted))
+                variant.IsActive = false;
+            changed = true;
+        }
+
+        if (changed)
+            await dbContext.SaveChangesAsync(cancellationToken);
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #142

Products removed from the Smartup catalog were never deactivated in the local database. After every daily sync, discontinued or out-of-catalog products kept `IsActive = true` and continued to appear on the storefront as purchasable. The catalog accumulated phantom products indefinitely.

### Root cause

`UpsertProductsAsync` upserted products returned by the API but never touched products that existed locally but were **absent** from the current response.

### Fix

- `SyncProductsAsync` now collects all `ProductId` values returned across every page of a category into `returnedProductIds`.
- After all pages are fetched, if no page errors occurred (`catErrors == 0`), the new `DeactivateMissingProductsAsync` method loads all locally-active external products for that category and sets `IsActive = false` on any whose `source_id` is not in `returnedProductIds`. Their variants are deactivated as well.
- Deactivation is deliberately skipped when a page fetch fails to avoid falsely deactivating products that simply weren't returned due to an API error.

## Files changed

- `src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs`
  - `SyncProductsAsync`: collect returned product IDs per category; call `DeactivateMissingProductsAsync` when all pages succeed
  - Added `DeactivateMissingProductsAsync`: loads active external products for a category and deactivates those absent from the API response

## Verification

Build verification (`dotnet build`) was not available in this environment (dotnet CLI not on PATH). The change is additive: no existing code paths were modified, only a new method added and called after the existing page loop. The logic mirrors the existing `UpsertProductsAsync` pattern for loading and saving entity changes.

## Risks / assumptions

- Products are considered removed only after all pages of their category fetch successfully — no false deactivations on partial failures.
- Products with no `source_id` in metadata are ignored (skipped by the `TryGetSourceId` guard), consistent with the existing upsert logic.
- Reactivation on the next sync is handled by the existing upsert path (`product.IsActive = true` when a product returns).


---
_Generated by [Claude Code](https://claude.ai/code/session_01VgkkkTwrpDSWoKqsFMrsUB)_