### PR TITLE
Fix #146: Reject Qty <= 0 in UpdateCartItemRequest validator

### DIFF
--- a/src/VendlyServer.Application/Services/Carts/Contracts/UpdateCartItemRequestValidator.cs
+++ b/src/VendlyServer.Application/Services/Carts/Contracts/UpdateCartItemRequestValidator.cs
@@ -6,6 +6,6 @@ public class UpdateCartItemRequestValidator : AbstractValidator<UpdateCartItemRe
 {
     public UpdateCartItemRequestValidator()
     {
-        RuleFor(x => x.Qty).GreaterThanOrEqualTo(0);
+        RuleFor(x => x.Qty).GreaterThan(0);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #146 (Finding 1)

`UpdateCartItemRequestValidator` used `GreaterThanOrEqualTo(0)`, which allowed `Qty = 0` to pass validation. `CartService.UpdateItemAsync` treats any `Qty <= 0` as a soft-delete, so a client sending `{"Qty": 0}` via `PUT /api/carts/items/{id}` would receive a `200 OK` while the item was silently removed — the same result as calling the `DELETE` endpoint but with no indication to the caller.

### Fix

Changed `GreaterThanOrEqualTo(0)` → `GreaterThan(0)` in `UpdateCartItemRequestValidator`, consistent with `CartItemRequestValidator` (used by `AddItemAsync`). Any `Qty <= 0` now returns a `400 Bad Request` before reaching the service. Cart item removal goes through the explicit `DELETE /api/carts/items/{id}` endpoint.

> Note: Issue #146 also describes a stock-check race condition (Finding 2) in `AddItemAsync`. That finding requires a serializable transaction and is tracked separately; it is not addressed in this PR.

## Files changed

- `src/VendlyServer.Application/Services/Carts/Contracts/UpdateCartItemRequestValidator.cs`
  - `GreaterThanOrEqualTo(0)` → `GreaterThan(0)`

## Verification

Build verification (`dotnet build`) was not available in this environment. The change is a single-line validator rule replacement that mirrors the existing `CartItemRequestValidator` pattern. No service logic was modified.

## Risks / assumptions

- Any frontend or integration currently relying on `Qty = 0` to remove items via `PUT` will now receive a `400`. The dedicated `DELETE /api/carts/items/{id}` endpoint is the correct way to remove items.
- Negative quantities already returned a `400` (since `>= 0` still blocked negatives); this change also blocks `0`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VgkkkTwrpDSWoKqsFMrsUB)_