### PR TITLE
Fix #143: Fail fast at startup when SmartupOptions fields are missing

### DIFF
--- a/src/VendlyServer.Infrastructure/Brokers/Smartup/SmartupOptions.cs
+++ b/src/VendlyServer.Infrastructure/Brokers/Smartup/SmartupOptions.cs
@@ -1,12 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace VendlyServer.Infrastructure.Brokers.Smartup;
 
 public class SmartupOptions
 {
     public const string SectionName = "Smartup";
 
+    [Required]
     public string BaseUrl { get; set; } = string.Empty;
+
+    [Required]
     public string ImageBaseUrl { get; set; } = string.Empty;
+
+    [Required]
     public string Token { get; set; } = string.Empty;
+
+    [Required]
     public string PersonId { get; set; } = string.Empty;
+
+    [Required]
     public string FilialId { get; set; } = string.Empty;
 }

--- a/src/VendlyServer.Infrastructure/Dependencies.cs
+++ b/src/VendlyServer.Infrastructure/Dependencies.cs
@@ -67,6 +67,9 @@ public static class Dependencies
     private static IServiceCollection ConfigureSmartup(this IServiceCollection services)
     {
         services.ConfigureOptions<SmartupOptionsSetup>();
+        services.AddOptions<SmartupOptions>()
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
         services.AddHttpClient("Smartup");
         services.AddSingleton<ISmartupBroker, SmartupBroker>();
 


### PR DESCRIPTION
## Summary

Fixes #143

`SmartupOptions` fields all defaulted to `string.Empty` with no validation. A deployment with missing or empty Smartup credentials would start successfully and only fail at the first scheduled sync job, surfacing as an opaque `UriFormatException` or HTTP 401 deep in the sync log — potentially hours after deployment.

### Fix

- Added `[Required]` data annotations to all five `SmartupOptions` fields (`BaseUrl`, `ImageBaseUrl`, `Token`, `PersonId`, `FilialId`).
- Registered `.ValidateDataAnnotations().ValidateOnStart()` in `ConfigureSmartup`, so the application refuses to start if any required field is absent or empty. This surfaces misconfiguration immediately at boot rather than silently at sync time.

The existing `SmartupOptionsSetup` binding is preserved — the `AddOptions<SmartupOptions>()` call chains validation on top of it.

## Files changed

- `src/VendlyServer.Infrastructure/Brokers/Smartup/SmartupOptions.cs`
  - Added `using System.ComponentModel.DataAnnotations`
  - Added `[Required]` to all five properties
- `src/VendlyServer.Infrastructure/Dependencies.cs`
  - Added `.AddOptions<SmartupOptions>().ValidateDataAnnotations().ValidateOnStart()` to `ConfigureSmartup`

## Verification

Build verification (`dotnet build`) was not available in this environment. The changes use the standard .NET `Microsoft.Extensions.Options` validation pipeline (`IValidateOptions<T>` / `ValidateOnStart`) which is part of `Microsoft.Extensions.Options.DataAnnotations` — already available in the project's dependency set.

## Risks / assumptions

- Any environment that currently runs without all five `Smartup` config keys will now fail to start. This is the intended behavior, but teams should verify all deployment environments have the full config before merging.
- `[Required]` on a `string` property rejects `null` and empty string (`""`). Values containing only whitespace are not caught — acceptable for this use case.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VgkkkTwrpDSWoKqsFMrsUB)_