### PR TITLE
Fix #146: Tighten UpdateCartItemRequest validator to reject Qty <= 0

### DIFF
--- a/src/VendlyServer.Application/Services/Carts/Contracts/UpdateCartItemRequestValidator.cs
+++ b/src/VendlyServer.Application/Services/Carts/Contracts/UpdateCartItemRequestValidator.cs
@@ -6,6 +6,6 @@ public class UpdateCartItemRequestValidator : AbstractValidator<UpdateCartItemRe
 {
     public UpdateCartItemRequestValidator()
     {
-        RuleFor(x => x.Qty).GreaterThanOrEqualTo(0);
+        RuleFor(x => x.Qty).GreaterThan(0);
     }
 }


### PR DESCRIPTION
Fixes #146

## Summary

`UpdateCartItemRequestValidator` used `GreaterThanOrEqualTo(0)`, which allowed `Qty=0` to pass validation. In `CartService.UpdateItemAsync`, any `Qty <= 0` silently soft-deletes the cart item and returns 200 OK — the same effect as calling the `DELETE` endpoint, with no indication to the caller.

Changed the rule to `GreaterThan(0)` so `Qty=0` and negative values return a 400 validation error, consistent with `CartItemRequestValidator` on the add path.

The validator is auto-registered via `AddValidatorsFromAssembly` in `Application/Dependencies.cs` and was already wired up — only the rule threshold was wrong.

> **Note:** The race condition in `AddItemAsync` (Finding 2 of the same issue) is not addressed here. It requires an architectural decision on the stock-guard strategy (serializable transaction vs. optimistic concurrency vs. advisory cart model) and should be tackled separately.

## Files Changed

- `src/VendlyServer.Application/Services/Carts/Contracts/UpdateCartItemRequestValidator.cs` — `GreaterThanOrEqualTo(0)` → `GreaterThan(0)`

## Verification

`dotnet build` / `dotnet test` could not be run — .NET SDK is not installed in the CI execution environment. The change is a single-word substitution of a known FluentValidation method with no structural risk.

## Risks / Assumptions

- If any existing client intentionally sends `Qty=0` expecting a silent delete (undocumented behaviour), it will now receive a 400. The correct path for removal is the `DELETE /api/carts/items/{id}` endpoint.
- The `Qty <= 0` soft-delete branch in `UpdateItemAsync` is preserved as a fallback; it simply becomes unreachable via the validated API path.

https://claude.ai/code/session_01ErEvFRkww6y72vyaMbJSLu

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErEvFRkww6y72vyaMbJSLu)_