### PR TITLE
Fix #142: Deactivate products absent from Smartup catalog after full-category sync

### DIFF
--- a/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
+++ b/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
@@ -182,6 +182,7 @@ public class SmartupSyncService(
             var catCreated = 0;
             var catUpdated = 0;
             var catErrors = 0;
+            var seenProductIds = new HashSet<string>();
 
             do
             {
@@ -200,6 +201,9 @@ public class SmartupSyncService(
                 var envelope = call.Result.Data!;
                 pageCount = envelope.GetPageCount();
 
+                foreach (var item in envelope.Products)
+                    seenProductIds.Add(item.ProductId);
+
                 var (c, u) = await UpsertProductsAsync(envelope.Products, categoryId, cancellationToken);
                 catCreated += c;
                 catUpdated += u;
@@ -209,6 +213,15 @@ public class SmartupSyncService(
                 page++;
             }
             while (page <= pageCount);
+
+            if (catErrors == 0)
+            {
+                var deactivated = await DeactivateMissingProductsAsync(seenProductIds, categoryId, cancellationToken);
+                if (deactivated > 0)
+                    logger.LogInformation(
+                        "Smartup Sync [{LogId}]: [{CategoryName}] — deactivated {Count} removed products",
+                        logId, cat.Name, deactivated);
+            }
 
             logger.LogInformation(
                 "Smartup Sync [{LogId}]: [{CategoryName}] — +{Created} ~{Updated} !{Errors}",
@@ -306,6 +319,33 @@ public class SmartupSyncService(
 
         await dbContext.SaveChangesAsync(cancellationToken);
         return (created, updated);
+    }
+
+    private async Task<int> DeactivateMissingProductsAsync(
+        HashSet<string> returnedIds, long categoryId, CancellationToken cancellationToken)
+    {
+        var dbProducts = await dbContext.Products
+            .Where(p => !p.IsDeleted && p.CategoryId == categoryId && p.SyncSource == SyncSource.External)
+            .Include(p => p.Variants)
+            .ToListAsync(cancellationToken);
+
+        var deactivated = 0;
+        foreach (var product in dbProducts)
+        {
+            if (!TryGetSourceId(product.Metadata, out var sourceId) || returnedIds.Contains(sourceId!))
+                continue;
+
+            product.IsActive = false;
+            foreach (var variant in product.Variants.Where(v => !v.IsDeleted))
+                variant.IsActive = false;
+
+            deactivated++;
+        }
+
+        if (deactivated > 0)
+            await dbContext.SaveChangesAsync(cancellationToken);
+
+        return deactivated;
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #142

## Summary

`SmartupSyncService.UpsertProductsAsync` correctly upserted products returned by the API but never touched products present in the local DB that were absent from the API response. Products discontinued or removed on the Smartup side remained `IsActive = true` indefinitely, continuing to appear as purchasable on the storefront.

**Root cause:** The upsert loop iterated only over `items` (the current API page). Products in `existingDict` whose key was not in `items` were silently ignored.

**Fix:** In `SyncProductsAsync`, a `seenProductIds` `HashSet<string>` accumulates all `ProductId` values returned across **all pages** of a category. After the page loop completes (and only when `catErrors == 0`, meaning all pages were fetched successfully), the new `DeactivateMissingProductsAsync` helper is called. It loads all non-deleted external products for the category, and for each whose `source_id` is absent from `seenProductIds`, sets `IsActive = false` on the product and all its non-deleted variants.

Key safety property: deactivation is **skipped** when `catErrors > 0` to avoid incorrectly marking products as removed when the sync only partially fetched a category.

## Files Changed

- `src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs`
  - Added `seenProductIds` tracking inside the per-category page loop
  - Added `DeactivateMissingProductsAsync` call after a clean (error-free) sync
  - Added private `DeactivateMissingProductsAsync` method (+27 lines)

## Verification

`dotnet build` / `dotnet test` could not be run — .NET SDK is not installed in the CI execution environment. The logic follows the same patterns as the existing `UpsertProductsAsync` method (same DB query, same `TryGetSourceId` helper, same `SaveChangesAsync` call pattern).

## Risks / Assumptions

- Products are only deactivated, not soft-deleted (`IsActive = false`, `IsDeleted` unchanged), preserving data and allowing re-activation if a product returns to the catalog.
- If a category sync fails mid-way (`catErrors > 0`), deactivation is skipped entirely for that category — no false removals.
- Products without a parseable `source_id` in metadata are ignored (safe — they cannot be matched to Smartup items anyway).

https://claude.ai/code/session_01ErEvFRkww6y72vyaMbJSLu

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErEvFRkww6y72vyaMbJSLu)_