### PR TITLE
Fix #154: Guard LocalStorageService against path-traversal via objectKey

### DIFF
--- a/src/VendlyServer.Application/Services/Storages/LocalStorageService.cs
+++ b/src/VendlyServer.Application/Services/Storages/LocalStorageService.cs
@@ -46,19 +46,17 @@ public class LocalStorageService(
 
     public Task<bool> ExistsAsync(string objectKey, CancellationToken cancellationToken = default)
     {
-        var fullPath = Path.Combine(
-            environment.WebRootPath, "uploads",
-            objectKey.Replace('/', Path.DirectorySeparatorChar));
-        return Task.FromResult(File.Exists(fullPath));
+        var fullPath = TryGetSafePath(objectKey);
+        return Task.FromResult(fullPath is not null && File.Exists(fullPath));
     }
 
     public async Task<Result<string>> UploadFromStreamAsync(
         Stream stream, string objectKey, string contentType, long size,
         CancellationToken cancellationToken = default)
     {
-        var fullPath = Path.Combine(
-            environment.WebRootPath, "uploads",
-            objectKey.Replace('/', Path.DirectorySeparatorChar));
+        var fullPath = TryGetSafePath(objectKey);
+        if (fullPath is null)
+            return StorageErrors.InvalidKey;
 
         Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
 
@@ -70,4 +68,13 @@ public class LocalStorageService(
 
     public string GetPublicUrl(string objectKey) =>
         $"{_options.BaseUrl}/uploads/{objectKey}";
+
+    private string? TryGetSafePath(string objectKey)
+    {
+        var uploadsRoot = Path.GetFullPath(Path.Combine(environment.WebRootPath, "uploads"));
+        var fullPath    = Path.GetFullPath(Path.Combine(uploadsRoot, objectKey.Replace('/', Path.DirectorySeparatorChar)));
+        return fullPath.StartsWith(uploadsRoot + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)
+            ? fullPath
+            : null;
+    }
 }

--- a/src/VendlyServer.Application/Services/Storages/StorageErrors.cs
+++ b/src/VendlyServer.Application/Services/Storages/StorageErrors.cs
@@ -7,4 +7,5 @@ public static class StorageErrors
     public static readonly Error UploadFailed = Error.Failure("Storage.UploadFailed");
     public static readonly Error DeleteFailed = Error.Failure("Storage.DeleteFailed");
     public static readonly Error InvalidUrl = Error.Failure("Storage.InvalidUrl");
+    public static readonly Error InvalidKey = Error.Failure("Storage.InvalidKey");
 }


### PR DESCRIPTION
## Summary

Fixes #154

`LocalStorageService.ExistsAsync` and `UploadFromStreamAsync` passed the caller-supplied `objectKey` directly into `Path.Combine` without verifying the resolved path stayed inside the `uploads` directory. A crafted key such as `../../../appsettings.json` (e.g. from a compromised Smartup API `PhotoSha` field) would silently resolve to a path outside the sandbox, allowing arbitrary file reads (`ExistsAsync`) or arbitrary file writes (`UploadFromStreamAsync`).

## Fix

Added a private `TryGetSafePath(string objectKey)` helper that:
1. Computes the canonical `uploadsRoot` via `Path.GetFullPath`.
2. Resolves the full target path via `Path.GetFullPath`.
3. Returns `null` if the resolved path does not start with `uploadsRoot + DirectorySeparatorChar` (i.e. escapes the sandbox).

Both methods now call `TryGetSafePath`:
- **`ExistsAsync`** — returns `false` for an invalid key (a traversal key has no valid upload).
- **`UploadFromStreamAsync`** — returns `Result.Failure(StorageErrors.InvalidKey)` for an invalid key, preventing any filesystem write.

A new `StorageErrors.InvalidKey` error code (`Storage.InvalidKey`) was added to surface this failure cleanly.

## Files changed

- `src/VendlyServer.Application/Services/Storages/LocalStorageService.cs` — add `TryGetSafePath`, use it in `ExistsAsync` and `UploadFromStreamAsync`
- `src/VendlyServer.Application/Services/Storages/StorageErrors.cs` — add `InvalidKey` error

## Verification

`dotnet` is not available in this execution environment; the build could not be run locally. The changes are syntactically straightforward C# with no new dependencies or interface changes. CI should confirm compilation and any existing tests.

## Risks / assumptions

- **Scope**: `LocalStorageService` is the dev/stub implementation. `MinioStorageService` passes `objectKey` to the MinIO SDK which does not perform local filesystem writes — it is unaffected.
- **Behaviour change**: `ExistsAsync` now returns `false` for traversal keys instead of resolving them. If a traversal key was previously returning `true` (highly unlikely in any legitimate scenario), the sync service will attempt an upload, which will now fail with `InvalidKey` rather than writing outside the sandbox.
- **No interface change**: `IStorageService` is unchanged.

https://claude.ai/code/session_011WESwyCgyALBmEt4P2zJgz

---
_Generated by [Claude Code](https://claude.ai/code/session_011WESwyCgyALBmEt4P2zJgz)_