### PR TITLE
Fix #147: Throw on SmartupCatalogSyncJob failure so Hangfire retries trigger

### DIFF
--- a/src/VendlyServer.Application/Jobs/SmartupCatalog/SmartupCatalogSyncJob.cs
+++ b/src/VendlyServer.Application/Jobs/SmartupCatalog/SmartupCatalogSyncJob.cs
@@ -14,6 +14,9 @@ public class SmartupCatalogSyncJob(
         var result = await smartupSyncService.SyncAsync(cancellationToken);
 
         if (result.IsFailure)
+        {
             logger.LogError("Smartup Catalog Sync job failed: {Error}", result.Error.Code);
+            throw new InvalidOperationException($"Smartup sync failed: {result.Error.Code}");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #147 (Finding 3 — sync job silently swallows failures)

`SmartupCatalogSyncJob.ExecuteAsync` was logging the error when `SyncAsync` returned a failure but then returning normally with exit code 0. Hangfire treats any job that returns without throwing as **succeeded**, so no retry was ever scheduled for transient Smartup API errors (network blips, 5xx responses, etc.). The failure was only visible in sync logs, not in Hangfire's failed-jobs queue.

The fix throws `InvalidOperationException` after logging, which causes Hangfire to mark the job as failed and enqueue it for automatic retry according to its retry policy.

Findings 1 and 2 of issue #147 (Hangfire default credentials and implicit-delete via `Qty ≤ 0`) are intentionally not addressed here — Finding 1 is a configuration change requiring secrets management decisions, and Finding 2 is a design/documentation concern already partially covered by existing PR #152.

## Files Changed

- `src/VendlyServer.Application/Jobs/SmartupCatalog/SmartupCatalogSyncJob.cs` — add `throw new InvalidOperationException(...)` after `LogError` in the failure branch

## Verification

`dotnet` is not available in this execution environment. The change adds a single `throw` statement inside an existing `if (result.IsFailure)` block. `InvalidOperationException` is available via BCL global usings with no new imports required. The pattern is syntactically trivial.

## Risks / Assumptions

- If no `[AutomaticRetry]` attribute is configured on the job or globally, Hangfire will use its default retry policy (10 attempts with exponential backoff). This is the intended behavior.
- Callers that previously observed a silent failure will now see an exception propagated through the Hangfire execution pipeline — this is an improvement, not a regression.
- The error message includes `result.Error.Code` which is already logged at `Error` level, so no new information is exposed beyond what was already in logs.

https://claude.ai/code/session_01QFFQ9KpJzcEMpffvY7WaeE

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFFQ9KpJzcEMpffvY7WaeE)_