### PR TITLE
Fix #89: Recreate missing variant in UpsertProductsAsync instead of silently skipping

### DIFF
--- a/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
+++ b/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
@@ -276,6 +276,20 @@ public class SmartupSyncService(
                     variant.Images = images;
                     variant.IsActive = true;
                 }
+                else
+                {
+                    logger.LogWarning(
+                        "Smartup Sync: product {ProductId} had no active variant; recreating",
+                        item.ProductId);
+                    dbContext.ProductVariants.Add(new ProductVariant
+                    {
+                        Product = product,
+                        Price = price,
+                        Quantity = quantity,
+                        Images = images,
+                        IsActive = true
+                    });
+                }
 
                 updated++;
             }


### PR DESCRIPTION
## Summary

Fixes #89 (Finding 1 — variant data silently skipped when product has no active variants)

`UpsertProductsAsync` would update product metadata and set `IsActive = true` for products that matched an existing Smartup source ID, but only updated variant data (`Price`, `Quantity`, `Images`) when `product.Variants.FirstOrDefault(v => !v.IsDeleted)` returned a non-null value. When all variants had been soft-deleted (e.g. by a prior manual edit or a partially failed sync), the product was left active on the storefront with stale or missing variant data and no error signal in sync logs.

The fix adds an `else` branch that creates a new `ProductVariant` and logs a `Warning` so the condition is observable.

Finding 2 (TOCTOU duplicate cart race condition) is intentionally not addressed here — it requires a database migration and application-level conflict handling, which is outside the scope of a bounded automated fix.

## Files Changed

- `src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs` — add `else` branch to `UpsertProductsAsync` that recreates the missing variant and emits a `LogWarning`

## Verification

`dotnet` is not available in this execution environment. The added code follows the identical pattern used in the `else` (new product) branch of the same method — `dbContext.ProductVariants.Add(new ProductVariant { Product = product, ... })` — so no new API surface is introduced. The `logger` field is already injected and used throughout the method. Syntactic correctness is confirmed by code inspection.

## Risks / Assumptions

- The new variant is created with the current sync's `price`, `quantity`, and `images`. This matches the intended behavior (fresh data from Smartup overwrites any stale state).
- The warning log uses `item.ProductId` which is the Smartup source ID, consistent with other log messages in the same method.
- Counting the recreated-variant case as `updated++` (not `created++`) is intentional: the product record already existed; only its variant is new.

https://claude.ai/code/session_01QFFQ9KpJzcEMpffvY7WaeE

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFFQ9KpJzcEMpffvY7WaeE)_