### PR TITLE
Fix #135: Clamp Page and PageSize in DataQueryRequest

### DIFF
--- a/src/VendlyServer.Domain/Abstractions/DataQueryRequest.cs
+++ b/src/VendlyServer.Domain/Abstractions/DataQueryRequest.cs
@@ -2,8 +2,21 @@ namespace VendlyServer.Domain.Abstractions;
 
 public record DataQueryRequest
 {
-    public int Page { get; set; } = 1;
-    public int PageSize { get; set; } = 20;
+    private int _page = 1;
+    private int _pageSize = 20;
+
+    public int Page
+    {
+        get => _page;
+        set => _page = Math.Clamp(value, 1, int.MaxValue);
+    }
+
+    public int PageSize
+    {
+        get => _pageSize;
+        set => _pageSize = Math.Clamp(value, 1, 100);
+    }
+
     public string? SortBy { get; set; }
     public SortDirection SortDirection { get; set; } = SortDirection.Asc;
 }


### PR DESCRIPTION
## Summary

Fixes #135

`DataQueryRequest.Page` had no lower-bound guard. Passing `?page=0` or `?page=-1` to any paginated endpoint caused EF Core to compute a negative `Skip()` argument, throwing `ArgumentOutOfRangeException` and propagating as an unhandled HTTP 500. `PageSize` also had no server-side cap, allowing unbounded table scans with a single request.

- Added backing field `_page` with `Math.Clamp(value, 1, int.MaxValue)` for `Page`
- Added backing field `_pageSize` with `Math.Clamp(value, 1, 100)` for `PageSize`

## Files Changed

- `src/VendlyServer.Domain/Abstractions/DataQueryRequest.cs`

## Verification

Build verification skipped — dotnet SDK not available in this automated environment. The change is a straightforward property-with-backing-field pattern using `Math.Clamp`, matching the recommendation in issue #135 and consistent with C# record semantics (non-positional record, no primary constructor parameters affected).

## Risks / Assumptions

- `PageSize` cap of 100 matches the recommendation in the issue. If individual endpoints need a higher limit, the clamp value can be adjusted.
- `int.MaxValue` for `Page` upper bound is safe; EF Core will handle very large page numbers gracefully (empty result).
- Existing callers that relied on `page=0` defaulting to the first page will now receive the first page explicitly (clamped to 1) — no silent behavior change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dexpd5VwqdcVK6dpgBcSNX)_