### PR TITLE
Fix #102: Allow unsetting default address via UpdateAsync

### DIFF
--- a/src/VendlyServer.Application/Services/Addresses/AddressService.cs
+++ b/src/VendlyServer.Application/Services/Addresses/AddressService.cs
@@ -146,7 +146,7 @@ public class AddressService(AppDbContext dbContext) : IAddressService
         address.House = request.House;
         address.Extra = request.Extra;
         address.BtsCityCode = request.BtsCityCode;
-        address.IsDefault = request.IsDefault || address.IsDefault;
+        address.IsDefault = request.IsDefault;
 
         await dbContext.SaveChangesAsync(cancellationToken);
 


### PR DESCRIPTION
## Summary

Fixes #102

`AddressService.UpdateAsync` used `address.IsDefault = request.IsDefault || address.IsDefault` — a one-way ratchet. Once an address was set as default, clients could never unset it through the update endpoint: sending `"isDefault": false` returned `200 OK` with `isDefault: true`, silently ignoring the client's intent.

**Root cause:** The OR expression preserved the existing `true` value even when the client explicitly sent `false`.

**Fix:** Replace the OR expression with a direct assignment `address.IsDefault = request.IsDefault`.

The guard block above (lines 132–140) already handles the "set new default → clear sibling defaults" case correctly and is unaffected by this change. When `request.IsDefault = false`, no sibling clearing is needed, and the assignment correctly unsets the flag.

## Files Changed

- `src/VendlyServer.Application/Services/Addresses/AddressService.cs` (line 149)

## Verification

Build verification skipped — dotnet SDK not available in this automated environment. The change is a single-line expression replacement with no logic added.

## Risks / Assumptions

- After this fix, calling `PUT /api/addresses/{id}` with `"isDefault": false` on the current default address will leave no address as default. This is acceptable per the issue recommendation. If the product requirement is "always have a default," that invariant should be enforced separately (e.g., at the business rule level or by auto-promoting another address, which `DeleteAsync` already does).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dexpd5VwqdcVK6dpgBcSNX)_