### PR TITLE
Fix #139: Log warning in MinioStorageService.ExistsAsync on unexpected exceptions

### DIFF
--- a/src/VendlyServer.Application/Services/Storages/MinioStorageService.cs
+++ b/src/VendlyServer.Application/Services/Storages/MinioStorageService.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Minio;
 using Minio.DataModel.Args;
@@ -8,7 +9,8 @@ namespace VendlyServer.Application.Services.Storages;
 public class MinioStorageService(
     IMinioClient minioClient,
     IOptions<MinioOptions> minioOptions,
-    IOptions<StorageOptions> storageOptions) : IStorageService
+    IOptions<StorageOptions> storageOptions,
+    ILogger<MinioStorageService> logger) : IStorageService
 {
     private readonly MinioOptions _minio = minioOptions.Value;
     private readonly StorageOptions _storage = storageOptions.Value;
@@ -94,12 +96,17 @@ public class MinioStorageService(
             await minioClient.StatObjectAsync(args, cancellationToken);
             return true;
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Minio.Exceptions.ObjectNotFoundException)
         {
             return false;
         }
-        catch
+        catch (Exception ex)
         {
+            logger.LogWarning(ex, "MinIO StatObject for {ObjectKey} threw an unexpected exception; treating as non-existent", objectKey);
             return false;
         }
     }


### PR DESCRIPTION
## Summary

Fixes #139

`MinioStorageService.ExistsAsync` had a bare `catch { return false; }` block that silently swallowed all non-`ObjectNotFoundException` errors (network failures, auth errors, timeouts). During a sync run, if MinIO was temporarily unavailable, every `ExistsAsync` call returned `false`, causing the sync job to re-download all catalog images from the Smartup CDN and then fail silently on upload — with no trace of the root cause in logs.

**Fix:**
- Add `ILogger<MinioStorageService>` to the constructor (primary constructor parameter)
- Add explicit `OperationCanceledException` handler (re-throw on cancellation, consistent with other methods in this class)
- Replace the bare `catch` with `catch (Exception ex)` that logs a `LogWarning` before returning `false`

The behavior on unexpected exceptions is unchanged (return `false`) — only observability is added.

## Files Changed

- `src/VendlyServer.Application/Services/Storages/MinioStorageService.cs`

## Verification

Build verification skipped — dotnet SDK not available in this automated environment. `ILogger<T>` is injected via DI and `Microsoft.Extensions.Logging` is already available in the Application project.

## Risks / Assumptions

- `ILogger<MinioStorageService>` is automatically provided by ASP.NET Core's DI container — no registration change required.
- The warning-then-return-false behavior is the minimal safe fix. A stricter alternative (re-throwing) would abort the sync on MinIO errors — left as a follow-up decision for the team.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dexpd5VwqdcVK6dpgBcSNX)_