### PR TITLE
Fix #165: Remove hardcoded Smartup JWT token from appsettings.json

### DIFF
--- a/src/VendlyServer.Api/appsettings.json
+++ b/src/VendlyServer.Api/appsettings.json
@@ -37,8 +37,8 @@
   "Smartup": {
     "BaseUrl": "https://erpbot-web.smartup.online",
     "ImageBaseUrl": "https://smartup.online",
-    "Token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwZXJzb25faWRzIjpbODQ1OTQ4XSwiY2hhdF9pZCI6OTA3NTY3OTU5LCJwYWdlIjoib3JkZXIiLCJob3N0X3VybCI6Imh0dHBzOi8vc21hcnR1cC5vbmxpbmUvIiwiaWF0IjoxNzc0Mzc2OTQ2fQ.W92TSjeX8bbpv3KTOQDfD8vcLWMRgnKsXrTtFFPzbiE",
-    "PersonId": "845948",
-    "FilialId": "826189"
+    "Token": "",
+    "PersonId": "",
+    "FilialId": ""
   }
 }


### PR DESCRIPTION
## Summary

Fixes #165

A live Smartup ERP API JWT token (`Token`), `PersonId`, and `FilialId` were committed directly into `src/VendlyServer.Api/appsettings.json`. This change replaces all three with empty placeholders so no live credentials are stored in the repository.

Real values must be injected at runtime via environment variables (`Smartup__Token`, `Smartup__PersonId`, `Smartup__FilialId`), which ASP.NET Core's configuration system maps automatically to the `Smartup:*` config keys.

> **Important:** The token is still present in git history. After merging, the Smartup API token should be revoked and re-issued, and git history should be scrubbed using `git filter-repo` or BFG Repo Cleaner if the repository is or could become public.

## Files changed

- `src/VendlyServer.Api/appsettings.json` — `Smartup.Token`, `Smartup.PersonId`, `Smartup.FilialId` set to `""`

## Verification

No compilation required (JSON-only change). Verified the resulting JSON is well-formed.

`dotnet build` could not be executed in the automated run environment (SDK not installed); the change is a pure value substitution with no code impact.

## Remaining risks / assumptions

- The token already exists in git history and is not neutralised by this PR alone — manual token rotation and history purge are required.
- CI/CD environments must supply `Smartup__Token` / `Smartup__PersonId` / `Smartup__FilialId` as env vars; the app will start with empty strings otherwise (downstream Smartup calls will fail with auth errors, not silently).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RLfDcm6vHEzUnEHjqz9hCW)_