### PR TITLE
Fix #163: Tighten global.json SDK rollForward to latestPatch

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,6 @@
 {
   "sdk": {
     "version": "10.0.201",
-    "rollForward": "latestMajor",
-    "allowPrerelease": true
+    "rollForward": "latestPatch"
   }
 }


### PR DESCRIPTION
## Summary

Fixes #163 (finding 1)

`global.json` had `"rollForward": "latestMajor"` combined with `"allowPrerelease": true`. This combination allows CI/CD agents to silently select a prerelease major version of the .NET SDK if one is installed, which can introduce breaking changes or unstable behaviour.

This PR changes `rollForward` to `"latestPatch"` (stays within the same major.minor) and removes `allowPrerelease`, making the SDK selection deterministic and production-safe.

**Finding 2 (SeedAsync removed) is a false alarm on the current `dev` branch.** `SeedAsync()` is still called — it was refactored into the `ApplyMigrationsAsync` extension method in `src/VendlyServer.Api/Dependencies.cs` (line `await dbContext.SeedAsync()`). No action needed there.

## Files changed

- `global.json` — `rollForward`: `latestMajor` → `latestPatch`; `allowPrerelease: true` removed

## Verification

No compilation required (JSON-only change). Verified the resulting JSON is well-formed.

## Remaining risks / assumptions

- If any team member's local machine only has a prerelease SDK installed and not `10.0.201`, they will need to install the stable SDK. This is the intended behaviour.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RLfDcm6vHEzUnEHjqz9hCW)_