### PR TITLE
Fix #162: Cap PageSize to 100 and floor Page to 1 in ProductService

### DIFF
--- a/src/VendlyServer.Application/Services/Products/ProductService.cs
+++ b/src/VendlyServer.Application/Services/Products/ProductService.cs
@@ -19,6 +19,9 @@ public class ProductService(
 
     public async Task<PagedList<ProductCardResponse>> GetAllAsync(ProductFilterRequest request, CancellationToken ct = default)
     {
+        var page = Math.Max(request.Page, 1);
+        var pageSize = Math.Clamp(request.PageSize, 1, 100);
+
         var baseQuery = dbContext.Products
             .AsNoTracking()
             .Where(p => !p.IsDeleted && p.IsActive)
@@ -30,8 +33,8 @@ public class ProductService(
             .Include(p => p.Category)
             .Include(p => p.Variants.Where(v => !v.IsDeleted && v.IsActive))
             .OrderByDescending(p => p.CreatedAt)
-            .Skip((request.Page - 1) * request.PageSize)
-            .Take(request.PageSize)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
             .ToListAsync(ct);
 
         var items = products.Select(p =>
@@ -53,8 +56,8 @@ public class ProductService(
         {
             Items = items,
             TotalCount = totalCount,
-            Page = request.Page,
-            PageSize = request.PageSize
+            Page = page,
+            PageSize = pageSize
         };
     }
 


### PR DESCRIPTION
## Summary

Fixes #162

`GET /api/products` is an `[AllowAnonymous]` endpoint. `ProductFilterRequest.PageSize` had no upper bound, so any unauthenticated caller could send `?pageSize=1000000` and trigger an arbitrarily large EF Core query (including eager-loaded `Category` and `Variants`). Additionally, `Page=0` produced `Skip(-20)`, which EF Core rejects with an unhandled `ArgumentOutOfRangeException` (HTTP 500).

This PR adds server-side clamping directly in `ProductService.GetAllAsync`:

```csharp
var page     = Math.Max(request.Page, 1);
var pageSize = Math.Clamp(request.PageSize, 1, 100);
```

The clamped values are then used for `Skip`/`Take` and are also reflected back in the `PagedList` response so the caller always sees what was actually used.

## Files changed

- `src/VendlyServer.Application/Services/Products/ProductService.cs` — `GetAllAsync` clamps `Page` and `PageSize` before use

## Verification

`dotnet build` could not be executed in the automated run environment (.NET SDK not installed). The change uses only `System.Math` BCL methods (`Math.Max`, `Math.Clamp`) available since .NET 6 and introduces no new dependencies or type changes.

## Remaining risks / assumptions

- The 100-item cap is a reasonable default; adjust if the storefront legitimately needs larger pages.
- Rate-limiting on this endpoint would provide additional protection against repeated scraping but is out of scope for this fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RLfDcm6vHEzUnEHjqz9hCW)_