### PR TITLE
Fix #162: Cap PageSize ≤ 100 and guard Page ≥ 1 on public product listing

### DIFF
--- a/src/VendlyServer.Application/Services/Products/Contracts/ProductFilterRequestValidator.cs
+++ b/src/VendlyServer.Application/Services/Products/Contracts/ProductFilterRequestValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace VendlyServer.Application.Services.Products.Contracts;
+
+public class ProductFilterRequestValidator : AbstractValidator<ProductFilterRequest>
+{
+    public ProductFilterRequestValidator()
+    {
+        RuleFor(x => x.Page).GreaterThan(0);
+        RuleFor(x => x.PageSize).InclusiveBetween(1, 100);
+    }
+}

--- a/src/VendlyServer.Application/Services/Products/ProductService.cs
+++ b/src/VendlyServer.Application/Services/Products/ProductService.cs
@@ -19,6 +19,9 @@ public class ProductService(
 
     public async Task<PagedList<ProductCardResponse>> GetAllAsync(ProductFilterRequest request, CancellationToken ct = default)
     {
+        var page = Math.Max(request.Page, 1);
+        var pageSize = Math.Clamp(request.PageSize, 1, 100);
+
         var baseQuery = dbContext.Products
             .AsNoTracking()
             .Where(p => !p.IsDeleted && p.IsActive)
@@ -30,8 +33,8 @@ public class ProductService(
             .Include(p => p.Category)
             .Include(p => p.Variants.Where(v => !v.IsDeleted && v.IsActive))
             .OrderByDescending(p => p.CreatedAt)
-            .Skip((request.Page - 1) * request.PageSize)
-            .Take(request.PageSize)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
             .ToListAsync(ct);
 
         var items = products.Select(p =>
@@ -53,8 +56,8 @@ public class ProductService(
         {
             Items = items,
             TotalCount = totalCount,
-            Page = request.Page,
-            PageSize = request.PageSize
+            Page = page,
+            PageSize = pageSize
         };
     }
 


### PR DESCRIPTION
## Summary

Fixes #162

`GET /api/products` is `[AllowAnonymous]` and accepted an unbounded `PageSize` query parameter. A caller could send `?pageSize=1000000` to trigger a `LIMIT 1000000` query with multiple eager-loaded navigations (`Category`, `Variants`, `Images`), exhausting DB CPU and memory. Additionally `Page=0` produced `Skip(-20)` which threw an unhandled `ArgumentOutOfRangeException` (500 to caller).

Two-layer fix:

1. **Validator** — `ProductFilterRequestValidator` (auto-registered via `AddValidatorsFromAssembly`) enforces `Page > 0` and `1 ≤ PageSize ≤ 100` at the pipeline level, returning 400 for out-of-range values.
2. **Service guard** — `ProductService.GetAllAsync` clamps `Page` and `PageSize` via `Math.Max`/`Math.Clamp` before any DB query, so the `PagedList` response always reflects the values actually used.

## Files changed

- `src/VendlyServer.Application/Services/Products/Contracts/ProductFilterRequestValidator.cs` — new file
- `src/VendlyServer.Application/Services/Products/ProductService.cs` — clamp `page`/`pageSize` in `GetAllAsync`

## Verification commands

```bash
dotnet build
dotnet test
```

The fix is logic-only (no schema migrations). Build verification confirms no compilation errors. The clamping is covered by the existing `AddValidatorsFromAssembly` registration in `Application/Dependencies.cs`.

## Remaining risks / assumptions

- The `ModelValidationFilter` checks `ModelState.IsValid`. Whether FluentValidation validators integrate with `ModelState` depends on whether `AddFluentValidationAutoValidation()` is wired up. If it is not (the `ConfigureControllers` call does not show it explicitly), the validator still acts as a registered service but the service-layer clamp is the effective runtime guard.
- The cap of 100 matches the recommendation in issue #162. If the product team needs a higher default it can be adjusted in one place (the validator + the `Math.Clamp` call).

---
_Generated by automated issue remediation — 2026-06-06_

---
_Generated by [Claude Code](https://claude.ai/code/session_01FR2UdUuis4UvKDPk1G6RM4)_