### PR TITLE
Fix #174: Replace RemoveRange with soft-delete in RecentlyViewedService

### DIFF
--- a/src/VendlyServer.Application/Services/RecentlyViewed/RecentlyViewedService.cs
+++ b/src/VendlyServer.Application/Services/RecentlyViewed/RecentlyViewedService.cs
@@ -12,7 +12,7 @@ public class RecentlyViewedService(AppDbContext dbContext) : IRecentlyViewedServ
     {
         return await dbContext.RecentlyViewedProducts
             .AsNoTracking()
-            .Where(r => r.UserId == userId)
+            .Where(r => r.UserId == userId && !r.IsDeleted)
             .OrderByDescending(r => r.ViewedAt)
             .Take(MaxItemsPerUser)
             .Select(r => new RecentlyViewedResponse(r.Id, r.ProductId, r.ViewedAt))
@@ -30,7 +30,7 @@ public class RecentlyViewedService(AppDbContext dbContext) : IRecentlyViewedServ
         var now = DateTime.UtcNow;
 
         var existing = await dbContext.RecentlyViewedProducts
-            .SingleOrDefaultAsync(r => r.UserId == userId && r.ProductId == request.ProductId, cancellationToken);
+            .SingleOrDefaultAsync(r => r.UserId == userId && r.ProductId == request.ProductId && !r.IsDeleted, cancellationToken);
 
         if (existing is not null)
         {
@@ -66,7 +66,7 @@ public class RecentlyViewedService(AppDbContext dbContext) : IRecentlyViewedServ
         if (validProductIds.Count == 0) return Result.Success();
 
         var existing = await dbContext.RecentlyViewedProducts
-            .Where(r => r.UserId == userId && validProductIds.Contains(r.ProductId))
+            .Where(r => r.UserId == userId && validProductIds.Contains(r.ProductId) && !r.IsDeleted)
             .ToListAsync(cancellationToken);
 
         var now = DateTime.UtcNow;
@@ -104,12 +104,14 @@ public class RecentlyViewedService(AppDbContext dbContext) : IRecentlyViewedServ
     public async Task<Result> ClearAsync(long userId, CancellationToken cancellationToken = default)
     {
         var entries = await dbContext.RecentlyViewedProducts
-            .Where(r => r.UserId == userId)
+            .Where(r => r.UserId == userId && !r.IsDeleted)
             .ToListAsync(cancellationToken);
 
         if (entries.Count == 0) return Result.Success();
 
-        dbContext.RecentlyViewedProducts.RemoveRange(entries);
+        foreach (var entry in entries)
+            entry.IsDeleted = true;
+
         await dbContext.SaveChangesAsync(cancellationToken);
         return Result.Success();
     }
@@ -117,14 +119,16 @@ public class RecentlyViewedService(AppDbContext dbContext) : IRecentlyViewedServ
     private async Task TrimToMaxAsync(long userId, CancellationToken cancellationToken)
     {
         var overflow = await dbContext.RecentlyViewedProducts
-            .Where(r => r.UserId == userId)
+            .Where(r => r.UserId == userId && !r.IsDeleted)
             .OrderByDescending(r => r.ViewedAt)
             .Skip(MaxItemsPerUser)
             .ToListAsync(cancellationToken);
 
         if (overflow.Count == 0) return;
 
-        dbContext.RecentlyViewedProducts.RemoveRange(overflow);
+        foreach (var entry in overflow)
+            entry.IsDeleted = true;
+
         await dbContext.SaveChangesAsync(cancellationToken);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #174

`RecentlyViewedService.ClearAsync` and `TrimToMaxAsync` were using `RemoveRange` (hard delete), violating the project's mandatory soft-delete rule. This change replaces `RemoveRange` with `IsDeleted = true` loops in both methods.

To make soft-delete work correctly end-to-end, all read queries in the service that previously omitted the `!r.IsDeleted` filter have also been fixed so soft-deleted entries are excluded from reads, lookups, and the trim count.

## Files Changed

- `src/VendlyServer.Application/Services/RecentlyViewed/RecentlyViewedService.cs`
  - `GetAllAsync`: added `&& !r.IsDeleted` to Where clause
  - `TrackAsync` existing-entry lookup: added `&& !r.IsDeleted`
  - `BulkSyncAsync` existing-entries lookup: added `&& !r.IsDeleted`
  - `ClearAsync`: replaced `RemoveRange` with soft-delete loop; query filtered to non-deleted entries
  - `TrimToMaxAsync`: replaced `RemoveRange` with soft-delete loop; query filtered to non-deleted entries

## Verification

`dotnet build` — .NET SDK was not available in the automated execution environment. The changes are additive-only (adding `!r.IsDeleted` predicate and replacing one call pattern with a foreach loop). No new types, methods, or dependencies were introduced.

## Risks / Assumptions

- `RecentlyViewedProduct` extends `AuditableModelBase<long>` which inherits from `ModelBase<TId>` — confirmed to carry `IsDeleted`. No schema change required.
- Existing soft-deleted rows in the `recently_viewed_products` table (if any from the old `RemoveRange` path) were hard-deleted and therefore do not exist; no data migration is needed.
- The trim now correctly counts only active (non-deleted) entries when deciding whether to soft-delete overflow rows.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhGC357naWygJikJ8y8XSj)_