### PR TITLE
Fix #162: Clamp PageSize and Page on anonymous product listing endpoint

### DIFF
--- a/src/VendlyServer.Application/Services/Products/ProductService.cs
+++ b/src/VendlyServer.Application/Services/Products/ProductService.cs
@@ -19,6 +19,9 @@ public class ProductService(
 
     public async Task<PagedList<ProductCardResponse>> GetAllAsync(ProductFilterRequest request, CancellationToken ct = default)
     {
+        var page = Math.Max(request.Page, 1);
+        var pageSize = Math.Clamp(request.PageSize, 1, 100);
+
         var baseQuery = dbContext.Products
             .AsNoTracking()
             .Where(p => !p.IsDeleted && p.IsActive)
@@ -30,8 +33,8 @@ public class ProductService(
             .Include(p => p.Category)
             .Include(p => p.Variants.Where(v => !v.IsDeleted && v.IsActive))
             .OrderByDescending(p => p.CreatedAt)
-            .Skip((request.Page - 1) * request.PageSize)
-            .Take(request.PageSize)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
             .ToListAsync(ct);
 
         var items = products.Select(p =>
@@ -54,8 +57,8 @@ public class ProductService(
         {
             Items = items,
             TotalCount = totalCount,
-            Page = request.Page,
-            PageSize = request.PageSize
+            Page = page,
+            PageSize = pageSize
         };
     }
 


### PR DESCRIPTION
## Summary

Fixes #162

`GET /api/products` is an `[AllowAnonymous]` endpoint. `ProductFilterRequest` had no upper bound on `PageSize`, allowing any unauthenticated caller to trigger arbitrarily large DB reads (including eager-loaded `Variants`). Additionally, `Page <= 0` produced a negative `Skip` value, causing a runtime `ArgumentOutOfRangeException` (HTTP 500).

Both parameters are now clamped server-side at the top of `ProductService.GetAllAsync`:
- `Page` is clamped to a minimum of 1
- `PageSize` is clamped to the inclusive range [1, 100]

## Files Changed

- `src/VendlyServer.Application/Services/Products/ProductService.cs`
  - `GetAllAsync`: compute `page = Math.Max(request.Page, 1)` and `pageSize = Math.Clamp(request.PageSize, 1, 100)` at the start; use both local variables in `Skip`, `Take`, and the returned `PagedList`

## Verification

`dotnet build` — .NET SDK was not available in the automated execution environment. The change uses only built-in `System.Math` methods and touches a single method body; no new dependencies or types were introduced.

## Risks / Assumptions

- The clamped `page`/`pageSize` values are returned in the `PagedList` response. Callers that sent an out-of-range `PageSize` (e.g. `1000000`) will receive `pageSize: 100` in the response, which is a clearer contract than silently accepting the oversized value.
- Rate limiting on this endpoint is still recommended as a defense-in-depth measure but is out of scope for this bounded fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhGC357naWygJikJ8y8XSj)_