### PR TITLE
Fix #169 #165: Remove hardcoded secrets from config files

### DIFF
--- a/src/VendlyServer.Api/appsettings.Production.json
+++ b/src/VendlyServer.Api/appsettings.Production.json
@@ -35,7 +35,7 @@
     "LocationLong": 69.24
   },
   "Jwt": {
-    "SecretKey": "ProdVendlySecretKeyasdqwe123dasdhtjdbnfkjasuid",
+    "SecretKey": "",
     "Issuer": "VendlyServer",
     "Audience": "VendlyClient",
     "ExpirationInMinutes": 120
@@ -55,7 +55,7 @@
   },
   "TelegramBot": {
     "Enabled": false,
-    "Token": "8729785259:AAGZvxgnYzhylTPervZHS51iF44wboHBFdg",
+    "Token": "",
     "PublicBaseUrl": "https://api-opto.vestor.uz",
     "MiniAppUrl": "https://opto.vestor.uz",
     "WebhookSecretToken": "MySecret",

--- a/src/VendlyServer.Api/appsettings.Staging.json
+++ b/src/VendlyServer.Api/appsettings.Staging.json
@@ -35,7 +35,7 @@
     "LocationLong": 69.24
   },
   "Jwt": {
-    "SecretKey": "StagingVendlySecretKeyasdqwe123dasdhtjdbnfkjasuid",
+    "SecretKey": "",
     "Issuer": "VendlyServer",
     "Audience": "VendlyClient",
     "ExpirationInMinutes": 120
@@ -55,7 +55,7 @@
   },
   "TelegramBot": {
     "Enabled": true,
-    "Token": "8729785259:AAGZvxgnYzhylTPervZHS51iF44wboHBFdg",
+    "Token": "",
     "PublicBaseUrl": "https://api-stage-opto.vestor.uz",
     "MiniAppUrl": "https://stage-opto.vestor.uz",
     "WebhookSecretToken": "MySecret",

--- a/src/VendlyServer.Api/appsettings.json
+++ b/src/VendlyServer.Api/appsettings.json
@@ -60,7 +60,7 @@
   "Smartup": {
     "BaseUrl": "https://erpbot-web.smartup.online",
     "ImageBaseUrl": "https://smartup.online",
-    "Token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwZXJzb25faWRzIjpbODQ1OTQ4XSwiY2hhdF9pZCI6OTA3NTY3OTU5LCJwYWdlIjoib3JkZXIiLCJob3N0X3VybCI6Imh0dHBzOi8vc21hcnR1cC5vbmxpbmUvIiwiaWF0IjoxNzc0Mzc2OTQ2fQ.W92TSjeX8bbpv3KTOQDfD8vcLWMRgnKsXrTtFFPzbiE",
+    "Token": "",
     "PersonId": "845948",
     "FilialId": "826189"
   }


### PR DESCRIPTION
## Summary

Fixes #169, Fixes #165

Three production secrets were committed directly to config files in version control:
1. **JWT signing key** in `appsettings.Production.json` and `appsettings.Staging.json` — allows forging access tokens for any user
2. **Telegram Bot Token** in both production and staging config — allows full bot account takeover
3. **Smartup API JWT token** in `appsettings.json` — grants authenticated read access to the ERP catalog/order API

This PR removes all three secret values and replaces them with empty strings. The secrets must be supplied at runtime via environment variables, which ASP.NET Core's configuration system automatically maps:

| Config key | Environment variable |
|---|---|
| `Jwt:SecretKey` | `Jwt__SecretKey` |
| `TelegramBot:Token` | `TelegramBot__Token` |
| `Smartup:Token` | `Smartup__Token` |

## Files Changed

- `src/VendlyServer.Api/appsettings.Production.json` — cleared `Jwt:SecretKey` and `TelegramBot:Token`
- `src/VendlyServer.Api/appsettings.Staging.json` — cleared `Jwt:SecretKey` and `TelegramBot:Token`
- `src/VendlyServer.Api/appsettings.json` — cleared `Smartup:Token`

## Verification

Config file edits only — no C# code changed, no build step required.

## ⚠️ Required Human Actions (not done by this PR)

This PR stops new deployments from receiving the compromised secrets. However, the secrets are still in git history and may already be exploited.

**Before merging, the team MUST:**
1. **Rotate the JWT signing key** — generate a new key and set `Jwt__SecretKey` in all deployment environments. All existing issued tokens will be invalidated; users will need to re-login.
2. **Revoke and regenerate the Telegram Bot Token** via `@BotFather` (`/revoke`), then re-register the webhook with the new token. Set `TelegramBot__Token` in deployment environments.
3. **Rotate the Smartup API token** with the Smartup account administrator. Set `Smartup__Token` in deployment environments.
4. **Purge git history** using `git filter-repo` or BFG Repo Cleaner to remove the committed secret values from all historical commits, then force-push and have all contributors re-clone.

**Additional secrets also in plain text** (not covered by referenced issues, flagged for awareness):
- Database password in `ConnectionStrings` (both Production and Staging)
- Minio `SecretKey` in both Production and Staging
- Hamkor payment gateway `Key` and `Secret` in both environments

These should be migrated to environment variables following the same pattern.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhGC357naWygJikJ8y8XSj)_