### PR TITLE
Fix #174: Replace RemoveRange with soft-delete in RecentlyViewedService

### DIFF
--- a/src/VendlyServer.Application/Services/RecentlyViewed/RecentlyViewedService.cs
+++ b/src/VendlyServer.Application/Services/RecentlyViewed/RecentlyViewedService.cs
@@ -12,7 +12,7 @@ public class RecentlyViewedService(AppDbContext dbContext) : IRecentlyViewedServ
     {
         return await dbContext.RecentlyViewedProducts
             .AsNoTracking()
-            .Where(r => r.UserId == userId)
+            .Where(r => r.UserId == userId && !r.IsDeleted)
             .OrderByDescending(r => r.ViewedAt)
             .Take(MaxItemsPerUser)
             .Select(r => new RecentlyViewedResponse(r.Id, r.ProductId, r.ViewedAt))
@@ -30,7 +30,7 @@ public class RecentlyViewedService(AppDbContext dbContext) : IRecentlyViewedServ
         var now = DateTime.UtcNow;
 
         var existing = await dbContext.RecentlyViewedProducts
-            .SingleOrDefaultAsync(r => r.UserId == userId && r.ProductId == request.ProductId, cancellationToken);
+            .SingleOrDefaultAsync(r => r.UserId == userId && r.ProductId == request.ProductId && !r.IsDeleted, cancellationToken);
 
         if (existing is not null)
         {
@@ -66,7 +66,7 @@ public class RecentlyViewedService(AppDbContext dbContext) : IRecentlyViewedServ
         if (validProductIds.Count == 0) return Result.Success();
 
         var existing = await dbContext.RecentlyViewedProducts
-            .Where(r => r.UserId == userId && validProductIds.Contains(r.ProductId))
+            .Where(r => r.UserId == userId && validProductIds.Contains(r.ProductId) && !r.IsDeleted)
             .ToListAsync(cancellationToken);
 
         var now = DateTime.UtcNow;
@@ -104,12 +104,14 @@ public class RecentlyViewedService(AppDbContext dbContext) : IRecentlyViewedServ
     public async Task<Result> ClearAsync(long userId, CancellationToken cancellationToken = default)
     {
         var entries = await dbContext.RecentlyViewedProducts
-            .Where(r => r.UserId == userId)
+            .Where(r => r.UserId == userId && !r.IsDeleted)
             .ToListAsync(cancellationToken);
 
         if (entries.Count == 0) return Result.Success();
 
-        dbContext.RecentlyViewedProducts.RemoveRange(entries);
+        foreach (var entry in entries)
+            entry.IsDeleted = true;
+
         await dbContext.SaveChangesAsync(cancellationToken);
         return Result.Success();
     }
@@ -117,14 +119,16 @@ public class RecentlyViewedService(AppDbContext dbContext) : IRecentlyViewedServ
     private async Task TrimToMaxAsync(long userId, CancellationToken cancellationToken)
     {
         var overflow = await dbContext.RecentlyViewedProducts
-            .Where(r => r.UserId == userId)
+            .Where(r => r.UserId == userId && !r.IsDeleted)
             .OrderByDescending(r => r.ViewedAt)
             .Skip(MaxItemsPerUser)
             .ToListAsync(cancellationToken);
 
         if (overflow.Count == 0) return;
 
-        dbContext.RecentlyViewedProducts.RemoveRange(overflow);
+        foreach (var entry in overflow)
+            entry.IsDeleted = true;
+
         await dbContext.SaveChangesAsync(cancellationToken);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #174

`RecentlyViewedService.ClearAsync` and `TrimToMaxAsync` were using `RemoveRange` (hard-delete), violating the project's mandatory soft-delete rule (`Remove() — ISHLATMA, IsDeleted = true ishlat`). Because `RecentlyViewedProduct` extends `AuditableModelBase<long>` → `ModelBase<long>` and therefore carries `IsDeleted`, the fix is straightforward.

**Changes made:**
- `ClearAsync`: replaced `dbContext.RecentlyViewedProducts.RemoveRange(entries)` with `foreach (var entry in entries) entry.IsDeleted = true`
- `TrimToMaxAsync`: same replacement for `overflow`
- All read queries in the service updated to include `!r.IsDeleted` filter (previously unnecessary due to hard-delete, now mandatory):
  - `GetAllAsync`
  - `TrackAsync` (lookup of existing entry)
  - `BulkSyncAsync` (lookup of existing entries)
  - `ClearAsync` (load entries to soft-delete)
  - `TrimToMaxAsync` (load overflow to soft-delete)

## Files Changed

- `src/VendlyServer.Application/Services/RecentlyViewed/RecentlyViewedService.cs`

## Verification

`dotnet` runtime was not available in this remote execution environment, so the build could not be run locally. The changes are syntactically correct C# that follow the established patterns used throughout the codebase (identical to how `CartService.ClearAsync` already does `foreach (var item in items) item.IsDeleted = true`).

## Risks / Assumptions

- This is a **soft-delete migration**: any existing records in `recently_viewed_products` that were previously removed via hard-delete cannot retroactively gain `IsDeleted = true`. Going forward, all removals will be soft-deletes.
- The `!r.IsDeleted` filter is consistent with every other entity in this codebase.
- No schema changes are required — `IsDeleted` column is already present via `ModelBase<long>`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XD3Tu2xLHJzfPWyba2Gzcg)_