### PR TITLE
Fix #125 #175: Replace .ContinueWith() with await + add AsNoTracking in SmartupSyncService

### DIFF
--- a/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
+++ b/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
@@ -98,7 +98,7 @@ public class SmartupSyncService(
         return Result.Success();
     }
 
-    // ── Categories ────────────────────────────────────────────────────────
+    // ── Categories ────────────────────────────────────────────────────────────────
 
     private async Task<(Dictionary<string, long> idMap, int created, int updated)> SyncCategoriesAsync(
         List<SmartupCategoryItem> categories, long logId, CancellationToken cancellationToken)
@@ -157,17 +157,19 @@ public class SmartupSyncService(
         logger.LogInformation("Smartup Sync [{LogId}]: categories — +{Created} ~{Updated}",
             logId, created, updated);
 
-        var idMap = await dbContext.Categories
+        var allCategories = await dbContext.Categories
+            .AsNoTracking()
             .Where(c => !c.IsDeleted && c.Metadata != null)
-            .ToListAsync(cancellationToken)
-            .ContinueWith(t => t.Result
-                .Where(c => TryGetSourceId(c.Metadata, out _))
-                .ToDictionary(c => GetSourceId(c.Metadata)!, c => c.Id));
+            .ToListAsync(cancellationToken);
+
+        var idMap = allCategories
+            .Where(c => TryGetSourceId(c.Metadata, out _))
+            .ToDictionary(c => GetSourceId(c.Metadata)!, c => c.Id);
 
         return (idMap, created, updated);
     }
 
-    // ── Products ──────────────────────────────────────────────────────────
+    // ── Products ────────────────────────────────────────────────────────────────
 
     private async Task<(int created, int updated, int errors, List<object> details)> SyncProductsAsync(
         List<SmartupCategoryItem> categories,
@@ -327,7 +329,7 @@ public class SmartupSyncService(
         return (created, updated);
     }
 
-    // ── Helpers ───────────────────────────────────────────────────────────
+    // ── Helpers ────────────────────────────────────────────────────────────────
 
     private static SyncLog CreateRequestLog<T>(string correlationId, SmartupCallResult<T> call)
     {


### PR DESCRIPTION
## Summary

Fixes #125
Fixes #175

`SmartupSyncService.SyncCategoriesAsync` was using `.ContinueWith()` to transform the category query result into an ID map. This pattern:
1. Does **not** propagate the `CancellationToken`, so cancellation during the query would not be honored for the transform
2. Wraps exceptions from a faulted task in `AggregateException`, breaking the uniform async exception handling
3. Accesses `t.Result` directly which re-throws as `AggregateException` rather than the original exception
4. Violates the mandatory `AsNoTracking()` rule for read-only queries (`AsNoTracking() — read so'rovlarda MAJBURIY`)

**Fix applied:**
```csharp
// Before
var idMap = await dbContext.Categories
    .Where(c => !c.IsDeleted && c.Metadata != null)
    .ToListAsync(cancellationToken)
    .ContinueWith(t => t.Result
        .Where(c => TryGetSourceId(c.Metadata, out _))
        .ToDictionary(c => GetSourceId(c.Metadata)!, c => c.Id));

// After
var allCategories = await dbContext.Categories
    .AsNoTracking()
    .Where(c => !c.IsDeleted && c.Metadata != null)
    .ToListAsync(cancellationToken);

var idMap = allCategories
    .Where(c => TryGetSourceId(c.Metadata, out _))
    .ToDictionary(c => GetSourceId(c.Metadata)!, c => c.Id);
```

## Files Changed

- `src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs`

## Verification

`dotnet` runtime was not available in this remote execution environment, so the build could not be run locally. The change is a pure mechanical transformation: removes `.ContinueWith()`, splits into two steps, adds `AsNoTracking()`. The resulting code is functionally identical in the success path and strictly better in the error and cancellation paths.

## Risks / Assumptions

- No behavioral change in the happy path.
- `AsNoTracking()` is safe here because the ID map is read-only — the entities are not modified after being loaded into the dictionary.
- The first query (category upsert) still uses tracking since those entities are updated; only the second query (ID map rebuild) is now `AsNoTracking()`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XD3Tu2xLHJzfPWyba2Gzcg)_