### PR TITLE
Fix #163: Restrict global.json SDK rollForward to latestPatch

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,6 @@
 {
   "sdk": {
     "version": "10.0.201",
-    "rollForward": "latestMajor",
-    "allowPrerelease": true
+    "rollForward": "latestPatch"
   }
 }


### PR DESCRIPTION
## Summary

Fixes #163

- Changed `rollForward` from `latestMajor` to `latestPatch` in `global.json`.
- Removed `allowPrerelease: true`.

The previous combination of `rollForward: latestMajor` + `allowPrerelease: true` could silently select a prerelease or a future-major .NET SDK on any CI agent or deployment host where a newer SDK is installed, causing non-deterministic builds. `latestPatch` keeps the selected SDK within the pinned major/minor version (`10.0.x`), which is safe and deterministic.

## Files changed

- `global.json`

## Verification

No build change expected. The locked SDK version (`10.0.201`) is unaffected; only the roll-forward policy changes.

## Risks / assumptions

- Assumes the project should stay on .NET 10 (the locked version). If a future migration to .NET 11+ is planned, `rollForward` should be updated at that time.
- `allowPrerelease` is safe to remove because the project targets a stable `10.0.201` release SDK.

---
_Generated by [Claude Code](https://claude.ai/code/session_017RyYf4r6uX3z1xsXdpvZbe)_