### PR TITLE
Fix #185: Add ProductFilterRequestValidator and restore ResultExtensions 500 default

### DIFF
--- a/src/VendlyServer.Application/Services/Products/Contracts/ProductFilterRequestValidator.cs
+++ b/src/VendlyServer.Application/Services/Products/Contracts/ProductFilterRequestValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace VendlyServer.Application.Services.Products.Contracts;
+
+public class ProductFilterRequestValidator : AbstractValidator<ProductFilterRequest>
+{
+    public ProductFilterRequestValidator()
+    {
+        RuleFor(x => x.Page).GreaterThan(0);
+        RuleFor(x => x.PageSize).InclusiveBetween(1, 100);
+    }
+}

--- a/src/VendlyServer.Application/Services/Products/ProductService.cs
+++ b/src/VendlyServer.Application/Services/Products/ProductService.cs
@@ -21,6 +21,9 @@ public class ProductService(
     public async Task<PagedList<ProductCardResponse>> GetAllAsync(ProductFilterRequest request,
         CancellationToken ct = default)
     {
+        var page = Math.Max(request.Page, 1);
+        var pageSize = Math.Clamp(request.PageSize, 1, 100);
+
         var baseQuery = dbContext.Products
             .AsNoTracking()
             .Where(p => !p.IsDeleted && p.IsActive)
@@ -32,8 +35,8 @@ public class ProductService(
             .Include(p => p.Category)
             .Include(p => p.Variants.Where(v => !v.IsDeleted && v.IsActive))
             .OrderByDescending(p => p.CreatedAt)
-            .Skip((request.Page - 1) * request.PageSize)
-            .Take(request.PageSize)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
             .ToListAsync(ct);
 
         var items = products.Select(p =>
@@ -59,8 +62,8 @@ public class ProductService(
         {
             Items = items,
             TotalCount = totalCount,
-            Page = request.Page,
-            PageSize = request.PageSize
+            Page = page,
+            PageSize = pageSize
         };
     }
 

--- a/src/VendlyServer.Infrastructure/Extensions/ResultExtensions.cs
+++ b/src/VendlyServer.Infrastructure/Extensions/ResultExtensions.cs
@@ -20,19 +20,21 @@ public static class ResultExtensions
 
     private static int GetStatusCode(ErrorType errorType) => errorType switch
     {
+        ErrorType.Failure      => StatusCodes.Status400BadRequest,
         ErrorType.Validation   => StatusCodes.Status400BadRequest,
         ErrorType.NotFound     => StatusCodes.Status404NotFound,
         ErrorType.Conflict     => StatusCodes.Status409Conflict,
         ErrorType.Unauthorized => StatusCodes.Status401Unauthorized,
-        _                      => StatusCodes.Status400BadRequest
+        _                      => StatusCodes.Status500InternalServerError
     };
 
     private static string GetTitle(ErrorType errorType) => errorType switch
     {
+        ErrorType.Failure      => "Bad Request",
         ErrorType.Validation   => "Bad Request",
         ErrorType.NotFound     => "Not Found",
         ErrorType.Conflict     => "Conflict",
         ErrorType.Unauthorized => "Unauthorized",
-        _                      => "Bad Request"
+        _                      => "Internal Server Error"
     };
 }


### PR DESCRIPTION
## Summary

Fixes #185
Fixes #162

Two related correctness fixes:

### 1. Unbounded `PageSize` on `GET /api/products` (anonymous endpoint)

`ProductFilterRequest` had no validator, allowing callers to send `?page=0&pageSize=1000000`, which would:
- Cause `Skip(-20)` with a negative page (ArgumentOutOfRangeException at DB level)
- Execute a full-table scan with all eager-loaded variants in memory

**Fix:**
- Added `ProductFilterRequestValidator` enforcing `Page > 0` and `1 ≤ PageSize ≤ 100`. The validator is automatically registered via `services.AddValidatorsFromAssembly(...)`.
- Added service-level clamping in `ProductService.GetAllAsync` as defence-in-depth: `Math.Max(page, 1)` and `Math.Clamp(pageSize, 1, 100)`. This guards the database query regardless of whether the upstream validator fires.

### 2. `ResultExtensions` catch-all returns 400 instead of 500

The `_` catch-all in `GetStatusCode` and `GetTitle` was changed (in commit `bc68a63`) from HTTP 500 / `"Internal Server Error"` to HTTP 400 / `"Bad Request"`. This silently reclassifies any future `ErrorType` values — or genuine server-side failures — as client errors, hiding them from monitoring tools that watch for 5xx.

**Fix:**
- Added an explicit `ErrorType.Failure => Status400BadRequest` case (preserving the current business-rule behavior for all existing `Error.Failure(...)` uses).
- Restored `_` to `Status500InternalServerError` / `"Internal Server Error"` so unhandled or future error types surface as server errors.

**No behavior change for any current error type** — all existing `ErrorType` values are now explicitly mapped.

## Files changed

- `src/VendlyServer.Application/Services/Products/Contracts/ProductFilterRequestValidator.cs` (new)
- `src/VendlyServer.Application/Services/Products/ProductService.cs` (clamping in `GetAllAsync`)
- `src/VendlyServer.Infrastructure/Extensions/ResultExtensions.cs` (explicit `Failure` case + restore 500 default)

## Verification

```
dotnet build
dotnet test
```

Manual: `GET /api/products?page=0&pageSize=9999999` should now return a bounded result instead of throwing or scanning the full table.

## Risks / assumptions

- The `ProductFilterRequestValidator` will only auto-enforce if `FluentValidation.AspNetCore` is configured (or the existing `ModelValidationFilter` receives FluentValidation results). The service-level clamp is unconditional and does not depend on this integration.
- `ErrorType.Failure → 400` maintains the existing HTTP contract for all callers. Only hypothetical new error types benefit from the restored 500 default.

---
_Generated by [Claude Code](https://claude.ai/code/session_017RyYf4r6uX3z1xsXdpvZbe)_