### PR TITLE
Fix #125: Replace ContinueWith with await and add AsNoTracking in SyncCategoriesAsync

### DIFF
--- a/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
+++ b/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
@@ -157,12 +157,14 @@ public class SmartupSyncService(
         logger.LogInformation("Smartup Sync [{LogId}]: categories — +{Created} ~{Updated}",
             logId, created, updated);
 
-        var idMap = await dbContext.Categories
+        var allCategoriesForMap = await dbContext.Categories
+            .AsNoTracking()
             .Where(c => !c.IsDeleted && c.Metadata != null)
-            .ToListAsync(cancellationToken)
-            .ContinueWith(t => t.Result
-                .Where(c => TryGetSourceId(c.Metadata, out _))
-                .ToDictionary(c => GetSourceId(c.Metadata)!, c => c.Id));
+            .ToListAsync(cancellationToken);
+
+        var idMap = allCategoriesForMap
+            .Where(c => TryGetSourceId(c.Metadata, out _))
+            .ToDictionary(c => GetSourceId(c.Metadata)!, c => c.Id);
 
         return (idMap, created, updated);
     }


### PR DESCRIPTION
## Summary

Fixes #125
Fixes #175

Two correctness fixes in `SmartupSyncService.SyncCategoriesAsync`:

### 1. `.ContinueWith()` replaced with `await`

The id-map rebuild query used `.ContinueWith(t => t.Result ...)` which:
- Does **not** propagate the `CancellationToken` to the continuation
- Does **not** respect the synchronization context
- Wraps exceptions from `ToListAsync` in an `AggregateException` via `t.Result`, making them harder to handle consistently with the rest of the async chain

**Fix:** Split into two statements — a plain `await` for the DB query, then an in-memory LINQ projection for the dictionary.

### 2. Missing `AsNoTracking()` on the id-map query

The second `Categories` query (used only to build `string → long` ID mappings) was executed without `AsNoTracking()`, violating the project rule: **`AsNoTracking()` — read so'rovlarda MAJBURIY**. At this point the `DbContext` already holds tracked `Category` entities from the first query (which modifies them); running a second tracked read introduces unnecessary change-tracker bookkeeping.

**Fix:** Added `AsNoTracking()` to the id-map rebuild query.

## Files changed

- `src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs`

## Verification

```
dotnet build
dotnet test
```

The logic is equivalent — the returned `idMap` dictionary is populated identically to before.

## Risks / assumptions

- No behavior change for the sync output. The only changes are in exception propagation semantics and EF Core change-tracker behavior.
- The first `Categories` query (for upsert) is intentionally tracked (entities are modified in-place), so `AsNoTracking()` is only added to the second query.

---
_Generated by [Claude Code](https://claude.ai/code/session_017RyYf4r6uX3z1xsXdpvZbe)_