### PR TITLE
Fix #165: Remove live Smartup API token from appsettings.json

### DIFF
--- a/src/VendlyServer.Api/appsettings.json
+++ b/src/VendlyServer.Api/appsettings.json
@@ -60,7 +60,7 @@
   "Smartup": {
     "BaseUrl": "https://erpbot-web.smartup.online",
     "ImageBaseUrl": "https://smartup.online",
-    "Token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwZXJzb25faWRzIjpbODQ1OTQ4XSwiY2hhdF9pZCI6OTA3NTY3OTU5LCJwYWdlIjoib3JkZXIiLCJob3N0X3VybCI6Imh0dHBzOi8vc21hcnR1cC5vbmxpbmUvIiwiaWF0IjoxNzc0Mzc2OTQ2fQ.W92TSjeX8bbpv3KTOQDfD8vcLWMRgnKsXrTtFFPzbiE",
+    "Token": "",
     "PersonId": "845948",
     "FilialId": "826189"
   }


### PR DESCRIPTION
## Summary

Fixes #165

A live Smartup ERP JWT token was committed directly into `appsettings.json`. The token granted any repository reader authenticated access to the Smartup catalog and order APIs (`/api/data`) under the configured person and filial accounts. Because the token has a static `iat` (issued-at) with no expiry, it remains valid indefinitely.

**Change:** Replace the hardcoded token value with an empty string. The real token must be supplied at runtime via the `Smartup__Token` environment variable, which ASP.NET Core automatically maps to `Smartup:Token`.

## Files Changed

- `src/VendlyServer.Api/appsettings.json` — `Smartup.Token` cleared to `""`

## Verification

No build step available in this remote environment (`dotnet` not installed). The change is a single string replacement in a JSON config file with no compilation required.

## Remaining Risks / Required Actions (human)

1. **Rotate the Smartup token immediately** with the Smartup account administrator — the committed token is permanently in git history and must be considered compromised regardless of this PR.
2. **Purge git history** using `git filter-repo` or BFG Repo Cleaner to remove the token from all historical commits, then coordinate a force-push and re-clone for all contributors.
3. **Set `Smartup__Token` environment variable** in all deployment environments before deploying this change, otherwise the Smartup sync job will fail with auth errors (correct and expected behaviour until the env var is set).

https://claude.ai/code/session_01AxPYWkYrbxqiS5WwQxDCVJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxPYWkYrbxqiS5WwQxDCVJ)_