### PR TITLE
Fix #169: Remove hardcoded JWT key and Telegram token from Production/Staging configs

### DIFF
--- a/src/VendlyServer.Api/appsettings.Production.json
+++ b/src/VendlyServer.Api/appsettings.Production.json
@@ -35,7 +35,7 @@
     "LocationLong": 69.24
   },
   "Jwt": {
-    "SecretKey": "ProdVendlySecretKeyasdqwe123dasdhtjdbnfkjasuid",
+    "SecretKey": "",
     "Issuer": "VendlyServer",
     "Audience": "VendlyClient",
     "ExpirationInMinutes": 120
@@ -55,7 +55,7 @@
   },
   "TelegramBot": {
     "Enabled": false,
-    "Token": "8729785259:AAGZvxgnYzhylTPervZHS51iF44wboHBFdg",
+    "Token": "",
     "PublicBaseUrl": "https://api-opto.vestor.uz",
     "MiniAppUrl": "https://opto.vestor.uz",
     "WebhookSecretToken": "MySecret",

--- a/src/VendlyServer.Api/appsettings.Staging.json
+++ b/src/VendlyServer.Api/appsettings.Staging.json
@@ -35,7 +35,7 @@
     "LocationLong": 69.24
   },
   "Jwt": {
-    "SecretKey": "StagingVendlySecretKeyasdqwe123dasdhtjdbnfkjasuid",
+    "SecretKey": "",
     "Issuer": "VendlyServer",
     "Audience": "VendlyClient",
     "ExpirationInMinutes": 120
@@ -55,7 +55,7 @@
   },
   "TelegramBot": {
     "Enabled": true,
-    "Token": "8729785259:AAGZvxgnYzhylTPervZHS51iF44wboHBFdg",
+    "Token": "",
     "PublicBaseUrl": "https://api-stage-opto.vestor.uz",
     "MiniAppUrl": "https://stage-opto.vestor.uz",
     "WebhookSecretToken": "MySecret",


### PR DESCRIPTION
## Summary

Fixes #169

Two production secrets were committed in `appsettings.Production.json` and `appsettings.Staging.json`:

1. **JWT signing key** (`Jwt:SecretKey`) — used by `JwtProvider.GenerateToken` with HMAC-SHA256. Anyone with the key can forge access tokens for any user/role, bypassing all authentication and authorization checks without touching the user database.
2. **Telegram Bot Token** (`TelegramBot:Token`) — grants full control over the bot account: re-registering the webhook, sending messages to all users, reading message history, or permanently disabling the bot.

Both secrets are present in both Production and Staging configs, meaning compromise of either environment's config file compromises both simultaneously.

**Change:** Replace both hardcoded values with empty strings. Real values must be supplied at runtime via environment variables:
- `Jwt__SecretKey` → maps to `Jwt:SecretKey`
- `TelegramBot__Token` → maps to `TelegramBot:Token`

## Files Changed

- `src/VendlyServer.Api/appsettings.Production.json` — `Jwt.SecretKey` and `TelegramBot.Token` cleared
- `src/VendlyServer.Api/appsettings.Staging.json` — same

## Verification

No build step available in this remote environment (`dotnet` not installed). The change is string replacements in JSON config files with no compilation required.

## Remaining Risks / Required Actions (human)

1. **Rotate the JWT signing key immediately** — issue new production and staging keys; all currently-issued access tokens become invalid and users will need to re-login (acceptable tradeoff).
2. **Revoke and regenerate the Telegram Bot Token immediately** via @BotFather (`/revoke`) — the existing token is permanently compromised.
3. **Set environment variables before deploying** (`Jwt__SecretKey`, `TelegramBot__Token`) otherwise the application will fail to authenticate requests and the Telegram bot will not initialize.
4. **Purge git history** using `git filter-repo` or BFG Repo Cleaner and coordinate a force-push and re-clone for all contributors.
5. Note: `appsettings.Production.json` also contains DB passwords, Minio credentials, and Hamkor bank API keys which were not the subject of this issue — those should be reviewed and rotated separately.

https://claude.ai/code/session_01AxPYWkYrbxqiS5WwQxDCVJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxPYWkYrbxqiS5WwQxDCVJ)_