### PR TITLE
Fix #192: Re-throw OperationCanceledException in SmartupBroker and add DisableConcurrentExecution to sync job

### DIFF
--- a/src/VendlyServer.Application/Jobs/SmartupCatalog/SmartupCatalogSyncJob.cs
+++ b/src/VendlyServer.Application/Jobs/SmartupCatalog/SmartupCatalogSyncJob.cs
@@ -1,8 +1,10 @@
+using Hangfire;
 using Microsoft.Extensions.Logging;
 using VendlyServer.Application.Services.SmartupSync;
 
 namespace VendlyServer.Application.Jobs.SmartupCatalog;
 
+[DisableConcurrentExecution(timeoutInSeconds: 0)]
 public class SmartupCatalogSyncJob(
     ISmartupSyncService smartupSyncService,
     ILogger<SmartupCatalogSyncJob> logger) : ISmartupCatalogSyncJob

--- a/src/VendlyServer.Infrastructure/Brokers/Smartup/SmartupBroker.cs
+++ b/src/VendlyServer.Infrastructure/Brokers/Smartup/SmartupBroker.cs
@@ -100,6 +100,11 @@ public class SmartupBroker(
             var data = JsonSerializer.Deserialize<T>(rawJson);
             return (data, responseBody, true, (int)sw.ElapsedMilliseconds, startedAt, finishedAt);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            sw.Stop();
+            throw;
+        }
         catch (Exception ex)
         {
             sw.Stop();


### PR DESCRIPTION
## Summary

Fixes #192

Two warnings from issue #192 are addressed in this PR:

**Warning 1 — `SmartupBroker.PostAsync` swallows `OperationCanceledException`**

The generic `catch (Exception ex)` block was converting job cancellations (e.g. Hangfire shutdown) into failure results instead of letting the cancellation propagate. This prevented graceful shutdown and produced misleading `SyncStatus.Error` or `SyncStatus.Partial` log entries for intentionally-stopped jobs.

Fix: Added `catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { sw.Stop(); throw; }` before the generic catch block — matching the pattern already used in `DownloadImageAsync` in the same class.

**Warning 2 — `SmartupCatalogSyncJob` has no concurrency guard**

The daily cron and a manual trigger from `POST /api/admin/sync-logs/trigger` could run simultaneously. Both instances would read the same `allDbCategories` snapshot, then both try to insert the same categories, creating duplicates.

Fix: Added `[DisableConcurrentExecution(timeoutInSeconds: 0)]` to `SmartupCatalogSyncJob`. A second instance that arrives while a sync is already running will fail fast instead of racing.

## Files changed

- `src/VendlyServer.Infrastructure/Brokers/Smartup/SmartupBroker.cs` — add specific `OperationCanceledException` catch before generic catch in `PostAsync`
- `src/VendlyServer.Application/Jobs/SmartupCatalog/SmartupCatalogSyncJob.cs` — add `[DisableConcurrentExecution(timeoutInSeconds: 0)]` attribute

## Verification

The .NET SDK is not available in the remote execution environment; `dotnet build` could not be run. The changes are syntactically straightforward:
- The catch block pattern is identical to `DownloadImageAsync` which already exists in the same file.
- `DisableConcurrentExecutionAttribute` is provided by `Hangfire.Core` (already referenced in the Application project csproj).

Manual verification: build the solution and confirm `dotnet build` passes before merging.

## Risks / assumptions

- `timeoutInSeconds: 0` means concurrent attempts are rejected immediately (no wait). If a slower timeout is preferred to allow the previous run to finish, adjust this value.
- The `OperationCanceledException` is only re-thrown when `cancellationToken.IsCancellationRequested` is true, so genuine HTTP timeout exceptions (where the token is not cancelled) still fall through to the generic error handler as before.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXfGn2nQGUETE8m5S8NFcf)_