### PR TITLE
feat: edit-until-paid cart + one unpaid order at a time

### DIFF
--- a/.claude/plans/soft-sleeping-pearl.md
+++ b/.claude/plans/soft-sleeping-pearl.md
@@ -1,150 +1,130 @@
-# Category Pricing + dynamic price markup
+# Edit-until-paid cart + one unpaid order at a time
 
 ## Context
 
-`ProductVariant.Price` is stored as a **USD base price** (from Smartup sync / admin). Today every product GET returns this raw USD number directly as if it were the final price. The business needs the storefront to show **soum prices** that are:
+Today the order flow is **one cart per user → one active order**:
+- `Cart` is a single per-user shopping cart (`CartService.FindCartWithItemsAsync` = first cart by `UserId`).
+- `POST /api/orders` (`OrderService.CreateDraftAsync`) snapshots that cart into a **Draft** order (reusing the single existing Draft/New order if present).
+- `CartService` blocks edits via `HasActiveOrderAsync` (`Cart.CheckoutInProgress`) the moment an order reaches `New`.
+- Hamkor webhook (`CheckoutService.HandleCallbackAsync`) confirms payment, then clears the user's cart.
 
-1. converted from USD → soum via the live CBU rate, then
-2. marked up by a **per-category** rule (percent **or** a fixed soum amount), with a **start/end date** window, then
-3. **rounded up** ("yaxshilash") to a configurable step.
+The user wants:
+1. **Edit the active order's cart until it is paid** — add/remove items while status is `Draft` or `New` (locked only at `Payed`).
+2. **Multiple "active" orders** — i.e. a user can have several orders being fulfilled (`Payed` → `Delivered`).
+3. **Create a new order after the previous is paid** — placing/paying must not permanently block new orders.
+4. **At most ONE unpaid order (`Draft`/`New`) at a time** — to create a *new* order, the previous one must be **at least `Payed`**.
 
-When a category has no active rule, a **global default** (default markup % + default rounding step) from `appsettings.json` is used. The same convert → markup → round transform must be applied everywhere a price is returned to the customer (product list, search, detail, cart) and captured at checkout (order snapshot).
+So the unpaid/checkout stage is a **single, editable order**; once paid it joins the set of in-fulfillment orders and a fresh one can begin.
 
-This requires: (a) a new **CategoryPrice** entity + CRUD API, (b) global default options, (c) a central **pricing service**, and (d) wiring that service into all customer-facing price surfaces.
+Decisions confirmed:
+- Each order owns its own `Cart` (1:1 via `Order.CartId`); paid orders keep their cart, the user gets a fresh open cart.
+- Cart editable in **Draft + New**, locked at **Payed**.
+- On cart change, the active draft's `OrderItem` snapshots + `Subtotal`/`TotalAmount` **auto re-sync**.
 
-Decisions confirmed with the user:
-- Global default lives in **appsettings.json** (`IOptions`), not DB.
-- Fixed-type value is **additive** markup (`soum + fixedValue`), same as percent.
-- Rounding = **ceil to step** (`Math.Ceiling(v / step) * step`).
-- Scope = **all product GETs + cart + order snapshot**. The detail endpoint is treated as a display surface (returns transformed price).
+**Prerequisite (build is currently broken):** the WIP edit to `Domain/Enums/OrderStatus.cs` removed `Accepted` and renumbered values (`Payed = 5` is now "payment confirmed"), but `CheckoutService` and `OrderStatusTransitions` still reference `OrderStatus.Accepted`.
 
 ---
 
-## 1. Domain — enum + entity
+## 1. Prerequisite — finish the `Accepted → Payed` rename
 
-**`Domain/Enums/PriceMarkupType.cs`**
+- `Application/Services/Checkout/CheckoutService.cs` (~131, ~134): `OrderStatus.Accepted` → `OrderStatus.Payed`.
+- `Application/Services/Orders/OrderStatusTransitions.cs` (~15, ~26): `OrderStatus.Accepted` → `OrderStatus.Payed`.
+- `grep` to confirm no other `OrderStatus.Accepted` refs.
+
+**Data migration** (enum stored as int; renumbered with an old/new `5` collision → single `CASE` so each branch sees the original value). In the new migration `Up()`, raw SQL on `orders.orders` **and** `orders.order_status_histories`:
+```sql
+UPDATE orders.orders SET status = CASE status
+  WHEN 1 THEN 5  WHEN 2 THEN 5   -- old Accepted, old Payed → Payed(5)
+  WHEN 3 THEN 10 WHEN 4 THEN 15  WHEN 5 THEN 20  WHEN 6 THEN 25
+  WHEN 7 THEN 30 WHEN 8 THEN 35  WHEN 9 THEN 40  WHEN 10 THEN 45
+  ELSE status END;  -- Draft(-1), New(0) unchanged
+```
+
+---
+
+## 2. Data model — open vs. consumed cart
+
+**`Domain/Entities/Orders/Cart.cs`** — add:
 ```csharp
-public enum PriceMarkupType { Percent, Fixed }
+public bool IsCheckedOut { get; set; }   // false = open shopping cart; true = attached to an order
 ```
+- **Open cart** = `Carts.Where(c => c.UserId == userId && !c.IsDeleted && !c.IsCheckedOut)` (get-or-create; the cart used before an order exists).
+- `Order.CartId` already links order→cart 1:1.
 
-**`Domain/Entities/Catalogs/CategoryPrice.cs`** — `AuditableModelBase<long>`, table `catalogs.category_prices`:
-```csharp
-public long CategoryId { get; set; }
-public PriceMarkupType MarkupType { get; set; }     // Percent yoki Fixed
-[Column(TypeName = "decimal(18,2)")] public decimal Value { get; set; }  // percent (e.g. 15) yoki soum miqdori
-[Column(TypeName = "decimal(18,2)")] public decimal? RoundingStep { get; set; } // null → default
-public DateTime? StartDate { get; set; }
-public DateTime? EndDate { get; set; }
-[ForeignKey(nameof(CategoryId))] public Category Category { get; set; } = null!;
-```
-Add `public ICollection<CategoryPrice> Prices { get; set; } = [];` to `Category.cs`.
-
-**`Infrastructure/Persistence/AppDbContext.cs`** — add `public DbSet<CategoryPrice> CategoryPrices { get; set; }`.
-
-Migration: `dotnet ef migrations add Add_CategoryPrice` (from `src/VendlyServer.Infrastructure`, startup project `../VendlyServer.Api`).
-
-A category may have multiple rows (scheduled windows). "Active" = `!IsDeleted && (StartDate == null || StartDate <= now) && (EndDate == null || EndDate >= now)`. If several match, pick the latest by `StartDate` then `CreatedAt`.
+Migration `Add_Cart_IsCheckedOut` — also carries the §1 enum data-migration SQL.
 
 ---
 
-## 2. Global default — Options (appsettings.json)
+## 3. The single "active cart" + re-sync (core behaviour)
 
-**`Application/Services/Pricing/PricingOptions.cs`** (mirror `CurrencyApiOptions` + `CurrencyApiOptionsSetup`):
-```csharp
-public const string SectionName = "Pricing";
-public decimal DefaultMarkupPercent { get; set; } = 0;   // default foiz
-public decimal DefaultRoundingStep  { get; set; } = 0;   // 0 → rounding off
+The user always edits **one** cart. Resolve it as:
+- If the user has a **Draft/New** order → that order's `Cart` (editing it re-syncs the order).
+- Else → the **open** cart (get-or-create, `IsCheckedOut == false`).
+
+`Application/Services/Carts/CartService.cs`:
+- Add `ResolveActiveCartAsync(userId)` → returns the active `Cart` **and** its linked Draft/New `Order` (or null). `GetOrCreateAsync`, `AddItemAsync`, `UpdateItemAsync`, `RemoveItemAsync` all operate on this.
+- **Remove** `HasActiveOrderAsync` + all `CheckoutInProgress` returns and `CartResponse.IsLocked` (the active cart is by definition never paid; once paid it stops being the active cart).
+- After any add/update/remove, **if the active cart belongs to a Draft/New order**: re-sync that order via the shared helper below, and **if its status is `New`, revert to `Draft`** (the prior Hamkor amount is stale → re-initiate required).
+- Pricing display already wired via `IProductPricingService`.
+
+**Shared re-sync helper** — extract the snapshot logic currently inside `CreateDraftAsync` into a reusable method (e.g. static `OrderItemSync.Apply(order, cart, pricing)` or a small internal service) used by both `CartService` and `OrderService`:
 ```
-Add `PricingOptionsSetup : IConfigureOptions<PricingOptions>` + register via `services.ConfigureOptions<PricingOptionsSetup>()` in `Dependencies.ConfigureApplication`.
-
-Add to **all** `appsettings*.json`:
-```json
-"Pricing": { "DefaultMarkupPercent": 0, "DefaultRoundingStep": 1000 }
+// soft-delete order.Items; rebuild from cart.Items using pricing.CalculateSoumPrice
+// (PriceSnap/TotalSnap); recompute Subtotal + TotalAmount (+ DeliveryCost)
 ```
+`CartService` already injects `IProductPricingService` for `CreateContextAsync`.
 
 ---
 
-## 3. Pricing service (core logic)
+## 4. OrderService — one draft, multiple paid, create-after-paid
 
-**`Application/Services/Pricing/`**: `IProductPricingService`, `ProductPricingService`, `PricingContext`, `PricingErrors`.
+`Application/Services/Orders/OrderService.cs`:
 
-`ProductPricingService(ICurrencyConverterService currency, AppDbContext db, IOptions<PricingOptions> options)`:
+**Create (`CreateDraftAsync`):**
+- **Guard:** if the user has any `Draft`/`New` order → `OrderErrors.ActiveOrderExists` (must pay/finish it first). This enforces "one unpaid at a time".
+- Else: load the **open** cart (non-empty, else `CartEmpty`), create a Draft order with `CartId = openCart.Id`, set `openCart.IsCheckedOut = true`, snapshot items via the shared helper.
+- **Remove** the old "reuse existing Draft/New order" branch.
+- After a previous order is `Payed`, the open cart resolves fresh → create works again (requirement 3).
 
-```csharp
-Task<Result<PricingContext>> CreateContextAsync(CancellationToken ct)
-```
-- `currency.GetUsdRateAsync(ct)` → if fail, return `PricingErrors.RateUnavailable`.
-- Load all active `CategoryPrice` rows (`AsNoTracking`, the active-window filter above), reduce to one rule per `CategoryId`.
-- Return `PricingContext(usdRate, rulesByCategoryId, options.Value)`.
-
-`PricingContext.CalculateSoumPrice(decimal usdPrice, long categoryId)`:
-```csharp
-var soum = usdPrice * _usdRate;
-var rule = _rules.GetValueOrDefault(categoryId);
-decimal markup = rule is null
-    ? soum * _defaults.DefaultMarkupPercent / 100m
-    : rule.MarkupType == PriceMarkupType.Percent ? soum * rule.Value / 100m : rule.Value;
-var final = soum + markup;
-var step = rule?.RoundingStep ?? _defaults.DefaultRoundingStep;
-return step > 0 ? Math.Ceiling(final / step) * step : final;
-```
-
-Loading the rate + rules **once per request** (context) avoids N CBU calls / N queries when mapping a list. Register `IProductPricingService` scoped in `Dependencies`.
-
-`PricingErrors.RateUnavailable = Error.Failure("Pricing.RateUnavailable")`.
-
-**Failure handling:** money path (checkout) must **hard-fail**; display paths fall back to raw price + a warning log (see §5).
+**Active orders / cancel:**
+- Replace `GetMyDraftAsync` with `GetActiveOrdersAsync(userId)` → all non-terminal orders (`Draft, New, Payed, Preparing, Shipped, InTransit, OutForDelivery`) — the "active" set.
+- `CancelMyDraftAsync` → `CancelDraftAsync(userId, orderId)` for the single Draft/New order.
+- Add `OrderErrors.ActiveOrderExists` (Conflict `Order.ActiveOrderExists`).
 
 ---
 
-## 4. CategoryPrice CRUD feature (12-step backend pattern)
+## 5. Checkout — remove user-cart clearing
 
-`Application/Services/CategoryPrices/`:
-- `CategoryPriceErrors.cs` — `NotFound`, `CategoryNotFound`.
-- `Contracts/CreateCategoryPriceRequest.cs` (CategoryId, MarkupType, Value, RoundingStep?, StartDate?, EndDate?) + `CreateCategoryPriceRequestValidator` (Value ≥ 0; if Percent, Value ≤ some sane max; EndDate ≥ StartDate when both set; category exists check stays in service).
-- `Contracts/UpdateCategoryPriceRequest.cs` + validator.
-- `Contracts/CategoryPriceResponse.cs` (Id, CategoryId, MarkupType, Value, RoundingStep, StartDate, EndDate, timestamps).
-- `ICategoryPriceService` + `CategoryPriceService` — full CRUD following `CategoryService`/`ProductService` conventions (`AsNoTracking` reads, soft-delete via `IsDeleted`, `SaveChangesAsync` only in service, `Result` returns, validate `CategoryId` exists on create/update).
-- Register in `Dependencies`.
-
-**`Api/Controllers/Catalog/CategoryPricesController.cs`** (`[Route("api/category-prices")]`, `[Authorize(Roles = "Admin,Manager")]`, XML comments) — GET all (optional `?categoryId=`), GET by id, POST, PUT, DELETE. Mirror `CategoriesController`.
+`Application/Services/Checkout/CheckoutService.cs`:
+- `InitiatePaymentAsync` stays `Draft`-only (cart edits in `New` revert to `Draft`, so re-initiation re-prices correctly).
+- In `HandleCallbackAsync`, **remove `ClearCartAsync(order.UserId)`** — the paid order keeps its own cart (locked by status); the user's next open cart is created fresh on demand. Delete `ClearCartAsync`.
 
 ---
 
-## 5. Apply transform at every price surface
+## 6. Controllers / endpoints
 
-Inject `IProductPricingService` into `ProductService`, `CartService`, `OrderService`. Build the context once at the start of each read/checkout.
-
-**`ProductService.GetAllAsync`** (`ProductCardResponse.MinPrice`): after `ToListAsync`, build context; map `MinPrice = ctx.CalculateSoumPrice((decimal)defaultVariant.Price, p.CategoryId)`. On context failure: log warning, leave raw price (method returns `PagedList`, not `Result`).
-
-**`ProductService.SearchAsync`**: change the SQL projection to select an intermediate (include `p.CategoryId` + raw min price), materialize, then map to `ProductSearchResponse` applying `CalculateSoumPrice` in memory. Same soft-fallback on context failure.
-
-**`ProductService.GetByIdAsync`** (`ProductAdminDetailResponse` → each `ProductVariantResponse.Price`): materialize is already in-DB projection; restructure to fetch raw, then map variants applying `CalculateSoumPrice(v.Price, p.CategoryId)`. (Per user: detail endpoint returns the transformed display price.)
-> ⚠️ Admin-edit caveat: this endpoint is also used by the admin panel. Admin variant-edit forms must treat the variant base price as raw USD and **not** re-submit the transformed value via `BulkUpdate`/`UpdateVariant`. Flagged for confirmation during implementation; the write endpoints themselves are unchanged (they accept raw USD).
-
-**`CartService.MapToResponse`**: convert from `static` to an instance method (or pass `PricingContext`); apply `CalculateSoumPrice(i.ProductVariant.Price, i.ProductVariant.Product.CategoryId)` per item; `TotalAmount` then sums transformed prices. `Product` is already `Include`d (CategoryId available). Build context in the public read method(s) that call `MapToResponse`. Soft-fallback to raw on failure.
-
-**`OrderService.CreateOrderAsync`** (money path — both the existing-draft branch and the new-order branch, lines ~82 & ~129): build context at method start; **if context fails, return `PricingErrors.RateUnavailable`** (no silent raw fallback). Set `PriceSnap = ctx.CalculateSoumPrice(variant.Price, variant.Product.CategoryId)` and `TotalSnap = PriceSnap * Qty`; `Subtotal`/`TotalAmount` computed from the transformed snapshot. `variant.Product` is already loaded. Order GETs read the stored snapshot unchanged (no double transform).
-
-No change to RecentlyViewed/Wishlist (they expose no price) or to admin product **list** (`GetAllAdminAsync` has no price).
+- `CartsController` — **shape unchanged**; now edits the active cart (open or the single draft) and re-syncs the draft. No more lock. No separate order-item endpoints needed.
+- `Api/Controllers/Orders/OrdersController.cs`:
+  - `GET /api/orders/active` → `GetActiveOrdersAsync` (replaces `GET /api/orders/draft`).
+  - `DELETE /api/orders/{id:long}` → `CancelDraftAsync` (replaces `DELETE /api/orders/draft`).
 
 ---
 
-## 6. Files touched (summary)
+## 7. Frontend impact (note — backend-first; separate follow-up)
 
-New: `PriceMarkupType.cs`, `CategoryPrice.cs`, `Pricing/*` (4 files), `CategoryPrices/*` (~7 files), `CategoryPricesController.cs`, migration.
-Edited: `Category.cs`, `AppDbContext.cs`, `Dependencies.cs`, `appsettings*.json` (×4), `ProductService.cs`, `CartService.cs`, `OrderService.cs`.
+`vendly-client` assumes single cart + single draft (`/api/orders/draft`, cart `IsLocked`). After this it should: keep using `/api/carts` (edits resolve to the active draft automatically), list in-fulfillment orders via `/api/orders/active`, and allow a new order once the prior is paid. Out of scope unless requested.
 
 ---
 
-## 7. Verification
+## 8. Verification
 
-1. `dotnet build` the solution — no errors.
-2. `dotnet ef database update` — `category_prices` table created.
-3. Set `Pricing.DefaultRoundingStep=1000`, `DefaultMarkupPercent=10` in `appsettings.Development.json`. Run the API.
-4. `GET /api/products` for a category **without** a CategoryPrice → verify `minPrice ≈ ceil(usd * cbuRate * 1.10 / 1000) * 1000`.
-5. `POST /api/category-prices` `{ categoryId, markupType: "Percent", value: 25, roundingStep: 5000 }`. Re-GET the same category → price now uses 25% + 5000 step. Repeat with `markupType: "Fixed", value: 30000` → verify additive fixed markup.
-6. Set a `startDate`/`endDate` window in the future → verify the rule is ignored (falls back to default) until active.
-7. `GET /api/products/{id}`, `GET /api/products/search?q=`, and cart GET → all show transformed soum prices.
-8. Add to cart → create order (`checkout`/order draft) → confirm `OrderItem.PriceSnap` is the transformed soum value; re-GET the order → snapshot unchanged.
-9. Temporarily break the CBU rate (bad API key) → checkout returns `Pricing.RateUnavailable`; product list logs a warning and degrades to raw (display only).
+1. `dotnet build` — `Accepted` errors gone.
+2. `dotnet ef database update` — `is_checked_out` added; existing statuses remapped (check one order before/after).
+3. `POST /api/carts/items` → `GET /api/carts` shows items (open cart).
+4. `POST /api/orders` → Draft created from open cart.
+5. `POST /api/carts/items` again → edits the **same draft's** cart; `GET /api/orders/{id}` shows re-synced `Subtotal`/`TotalAmount`.
+6. `POST /api/orders` again → `Order.ActiveOrderExists` (draft still unpaid).
+7. `POST /api/orders/{id}/payment` → `New`; then `POST /api/carts/items` → succeeds and order reverts to `Draft`.
+8. Simulate webhook confirm → `Payed`; `GET /api/carts` now returns a **fresh empty** open cart; `POST /api/orders` → new Draft (requirement 3 ✓).
+9. `GET /api/orders/active` lists the paid order + the new draft.
+10. `dotnet test` — fix `CartServiceTests` (lock removed); add coverage for one-draft guard + edit-until-paid + create-after-paid.

--- a/src/VendlyServer.Api/Controllers/Orders/OrdersController.cs
+++ b/src/VendlyServer.Api/Controllers/Orders/OrdersController.cs
@@ -38,19 +38,19 @@ public class OrdersController(IOrderService orderService, ICheckoutService check
         return result.IsSuccess ? Results.Ok(result.Data) : result.ToProblemDetails();
     }
 
-    /// <summary>Cancel the current user's active draft order and unlock the cart.</summary>
-    [HttpDelete("draft")]
-    public async Task<IResult> CancelMyDraftAsync(CancellationToken cancellationToken = default)
+    /// <summary>Cancel one of the current user's unpaid (draft/new) orders.</summary>
+    [HttpDelete("{id:long}")]
+    public async Task<IResult> CancelDraftAsync(long id, CancellationToken cancellationToken = default)
     {
-        var result = await orderService.CancelMyDraftAsync(UserId, cancellationToken);
+        var result = await orderService.CancelDraftAsync(UserId, id, cancellationToken);
         return result.IsSuccess ? Results.Ok() : result.ToProblemDetails();
     }
 
-    /// <summary>Get the current user's active draft or new order (if any).</summary>
-    [HttpGet("draft")]
-    public async Task<IResult> GetMyDraftAsync(CancellationToken cancellationToken = default)
+    /// <summary>List the current user's active orders (draft/new + in-fulfillment).</summary>
+    [HttpGet("active")]
+    public async Task<IResult> GetActiveAsync(CancellationToken cancellationToken = default)
     {
-        var result = await orderService.GetMyDraftAsync(UserId, cancellationToken);
+        var result = await orderService.GetActiveOrdersAsync(UserId, cancellationToken);
         return result.IsSuccess ? Results.Ok(result.Data) : result.ToProblemDetails();
     }
 

--- a/src/VendlyServer.Api/Properties/launchSettings.json
+++ b/src/VendlyServer.Api/Properties/launchSettings.json
@@ -9,6 +9,15 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5052",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
     }
   }
 }

--- a/src/VendlyServer.Application/Services/Carts/CartService.cs
+++ b/src/VendlyServer.Application/Services/Carts/CartService.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using VendlyServer.Application.Services.Carts.Contracts;
+using VendlyServer.Application.Services.Orders;
 using VendlyServer.Application.Services.Pricing;
 using VendlyServer.Domain.Abstractions;
 using VendlyServer.Domain.Entities.Orders;
@@ -16,18 +17,9 @@ public class CartService(
 {
     public async Task<Result<CartResponse>> GetOrCreateAsync(long userId, CancellationToken cancellationToken = default)
     {
-        var cart = await FindCartWithItemsAsync(userId, cancellationToken);
-
-        if (cart is null)
-        {
-            cart = new Cart { UserId = userId };
-            dbContext.Carts.Add(cart);
-            await dbContext.SaveChangesAsync(cancellationToken);
-        }
-
-        var locked = await HasActiveOrderAsync(cart.Id, cancellationToken);
+        var (cart, _) = await ResolveActiveCartAsync(userId, cancellationToken);
         var pricing = await ResolvePricingContextAsync(cancellationToken);
-        return MapToResponse(cart, pricing, locked);
+        return MapToResponse(cart, pricing);
     }
 
     public async Task<Result<CartResponse>> AddItemAsync(long userId, CartItemRequest request, CancellationToken cancellationToken = default)
@@ -39,24 +31,12 @@ public class CartService(
 
         if (variant is null) return CartErrors.VariantNotFound;
 
-        var cart = await FindCartWithItemsAsync(userId, cancellationToken);
+        var (cart, _) = await ResolveActiveCartAsync(userId, cancellationToken);
 
-        if (cart is not null && await HasActiveOrderAsync(cart.Id, cancellationToken))
-            return CartErrors.CheckoutInProgress;
-
-        if (cart is null)
-        {
-            cart = new Cart { UserId = userId };
-            dbContext.Carts.Add(cart);
-            await dbContext.SaveChangesAsync(cancellationToken);
-            cart = await FindCartWithItemsAsync(userId, cancellationToken);
-        }
-
-        var existingItem = cart!.Items
+        var existingItem = cart.Items
             .FirstOrDefault(i => i.ProductVariantId == request.ProductVariantId && !i.IsDeleted);
 
         var newQty = existingItem is not null ? existingItem.Qty + request.Qty : request.Qty;
-
         if (newQty > variant.Quantity) return CartErrors.InsufficientStock;
 
         if (existingItem is not null)
@@ -67,34 +47,21 @@ public class CartService(
         {
             cart.Items.Add(new CartItem
             {
-                CartId           = cart.Id,
+                CartId = cart.Id,
                 ProductVariantId = request.ProductVariantId,
-                Qty              = request.Qty,
+                Qty = request.Qty,
             });
         }
 
         await dbContext.SaveChangesAsync(cancellationToken);
-
-        var updated = await FindCartWithItemsAsync(userId, cancellationToken);
-        var pricing = await ResolvePricingContextAsync(cancellationToken);
-        return MapToResponse(updated!, pricing);
+        return await FinishAsync(userId, cancellationToken);
     }
 
     public async Task<Result<CartResponse>> UpdateItemAsync(long userId, long cartItemId, UpdateCartItemRequest request, CancellationToken cancellationToken = default)
     {
-        var cart = await dbContext.Carts
-            .Where(c => c.UserId == userId && !c.IsDeleted)
-            .Include(c => c.Items.Where(i => !i.IsDeleted))
-                .ThenInclude(i => i.ProductVariant)
-                    .ThenInclude(v => v.Product)
-            .SingleOrDefaultAsync(cancellationToken);
+        var (cart, _) = await ResolveActiveCartAsync(userId, cancellationToken);
 
-        if (cart is null) return CartErrors.ItemNotFound;
-
-        if (await HasActiveOrderAsync(cart.Id, cancellationToken))
-            return CartErrors.CheckoutInProgress;
-
-        var item = cart.Items.SingleOrDefault(i => i.Id == cartItemId);
+        var item = cart.Items.FirstOrDefault(i => i.Id == cartItemId && !i.IsDeleted);
         if (item is null) return CartErrors.ItemNotFound;
 
         if (request.Qty <= 0)
@@ -108,62 +75,116 @@ public class CartService(
         }
 
         await dbContext.SaveChangesAsync(cancellationToken);
-        var pricing = await ResolvePricingContextAsync(cancellationToken);
-        return MapToResponse(cart, pricing);
+        return await FinishAsync(userId, cancellationToken);
     }
 
     public async Task<Result<CartResponse>> RemoveItemAsync(long userId, long cartItemId, CancellationToken cancellationToken = default)
     {
-        var cart = await dbContext.Carts
-            .Where(c => c.UserId == userId && !c.IsDeleted)
-            .Include(c => c.Items.Where(i => !i.IsDeleted))
-                .ThenInclude(i => i.ProductVariant)
-                    .ThenInclude(v => v.Product)
-            .SingleOrDefaultAsync(cancellationToken);
+        var (cart, _) = await ResolveActiveCartAsync(userId, cancellationToken);
 
-        if (cart is null) return CartErrors.ItemNotFound;
-
-        if (await HasActiveOrderAsync(cart.Id, cancellationToken))
-            return CartErrors.CheckoutInProgress;
-
-        var item = cart.Items.SingleOrDefault(i => i.Id == cartItemId);
+        var item = cart.Items.FirstOrDefault(i => i.Id == cartItemId && !i.IsDeleted);
         if (item is null) return CartErrors.ItemNotFound;
 
         item.IsDeleted = true;
+
         await dbContext.SaveChangesAsync(cancellationToken);
-        var pricing = await ResolvePricingContextAsync(cancellationToken);
-        return MapToResponse(cart, pricing);
+        return await FinishAsync(userId, cancellationToken);
     }
 
     public async Task<Result> ClearAsync(long userId, CancellationToken cancellationToken = default)
     {
-        var items = await dbContext.CartItems
-            .Where(i => i.Cart.UserId == userId && !i.IsDeleted)
-            .ToListAsync(cancellationToken);
+        var (cart, order) = await ResolveActiveCartAsync(userId, cancellationToken);
 
-        foreach (var item in items)
+        foreach (var item in cart.Items.Where(i => !i.IsDeleted))
             item.IsDeleted = true;
 
+        await ReSyncDraftOrderAsync(order, cart, cancellationToken);
         await dbContext.SaveChangesAsync(cancellationToken);
         return Result.Success();
     }
 
-    private Task<bool> HasActiveOrderAsync(long cartId, CancellationToken cancellationToken) =>
-        dbContext.Orders.AnyAsync(
-            o => o.CartId == cartId &&
-                 o.Status == OrderStatus.New &&
-                 !o.IsDeleted,
-            cancellationToken);
-
-    private async Task<Cart?> FindCartWithItemsAsync(long userId, CancellationToken cancellationToken)
+    // Aktiv cartni topadi: Draft/New order bo'lsa — uning carti (tahrir order'ni re-sync qiladi),
+    // aks holda open shopping cart (get-or-create).
+    private async Task<(Cart cart, Order? order)> ResolveActiveCartAsync(long userId, CancellationToken cancellationToken)
     {
-        return await dbContext.Carts
-            .Where(c => c.UserId == userId && !c.IsDeleted)
+        var order = await dbContext.Orders
+            .Where(o => o.UserId == userId && !o.IsDeleted &&
+                        (o.Status == OrderStatus.Draft || o.Status == OrderStatus.New))
+            .Include(o => o.Items.Where(i => !i.IsDeleted))
+            .Include(o => o.Cart)
+                .ThenInclude(c => c!.Items.Where(i => !i.IsDeleted))
+                    .ThenInclude(i => i.ProductVariant)
+                        .ThenInclude(v => v.Product)
+            .Include(o => o.Cart)
+                .ThenInclude(c => c!.Items.Where(i => !i.IsDeleted))
+                    .ThenInclude(i => i.ProductVariant)
+                        .ThenInclude(v => v.Measurements)
+            .OrderByDescending(o => o.CreatedAt)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (order?.Cart is not null)
+            return (order.Cart, order);
+
+        var cart = await LoadOpenCartAsync(userId, cancellationToken);
+        if (cart is null)
+        {
+            cart = new Cart { UserId = userId };
+            dbContext.Carts.Add(cart);
+            await dbContext.SaveChangesAsync(cancellationToken);
+            cart = await LoadOpenCartAsync(userId, cancellationToken);
+        }
+
+        return (cart!, null);
+    }
+
+    private Task<Cart?> LoadOpenCartAsync(long userId, CancellationToken cancellationToken) =>
+        dbContext.Carts
+            .Where(c => c.UserId == userId && !c.IsDeleted && !c.IsCheckedOut)
             .Include(c => c.Items.Where(i => !i.IsDeleted))
                 .ThenInclude(i => i.ProductVariant)
                     .ThenInclude(v => v.Product)
+            .Include(c => c.Items.Where(i => !i.IsDeleted))
+                .ThenInclude(i => i.ProductVariant)
+                    .ThenInclude(v => v.Measurements)
             .OrderBy(c => c.CreatedAt)
             .FirstOrDefaultAsync(cancellationToken);
+
+    // Mutatsiyadan keyin: cartni qayta yuklab (yangi itemlar bilan), draft order'ni re-sync qiladi va javob qaytaradi.
+    private async Task<Result<CartResponse>> FinishAsync(long userId, CancellationToken cancellationToken)
+    {
+        var (cart, order) = await ResolveActiveCartAsync(userId, cancellationToken);
+        var pricing = await ResolvePricingContextAsync(cancellationToken);
+
+        if (order is not null && pricing is not null)
+        {
+            OrderItemSync.Apply(order, cart.Items, pricing);
+            RevertToDraftIfNew(order);
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return MapToResponse(cart, pricing);
+    }
+
+    private async Task ReSyncDraftOrderAsync(Order? order, Cart cart, CancellationToken cancellationToken)
+    {
+        if (order is null) return;
+        var pricing = await ResolvePricingContextAsync(cancellationToken);
+        if (pricing is null) return;
+
+        OrderItemSync.Apply(order, cart.Items, pricing);
+        RevertToDraftIfNew(order);
+    }
+
+    // To'lov boshlangan (New) order tahrirlansa — eski Hamkor summasi eskirgan → Draft'ga qaytaramiz.
+    private static void RevertToDraftIfNew(Order order)
+    {
+        if (order.Status != OrderStatus.New) return;
+        order.Status = OrderStatus.Draft;
+        order.StatusHistory.Add(new OrderStatusHistory
+        {
+            Status = OrderStatus.Draft,
+            Note = "Reverted to draft after cart edit",
+        });
     }
 
     // USD rate / category rule'lar bo'lmasa savatchada raw narx qoladi (warning bilan)
@@ -178,7 +199,7 @@ public class CartService(
         return null;
     }
 
-    private static CartResponse MapToResponse(Cart cart, PricingContext? pricing, bool isLocked = false)
+    private static CartResponse MapToResponse(Cart cart, PricingContext? pricing)
     {
         var items = cart.Items
             .Where(i => !i.IsDeleted)
@@ -197,6 +218,6 @@ public class CartService(
             .ToList();
 
         var total = items.Sum(i => i.Price * i.Qty);
-        return new CartResponse(cart.Id, items, total, IsLocked: isLocked);
+        return new CartResponse(cart.Id, items, total, IsLocked: false);
     }
 }

--- a/src/VendlyServer.Application/Services/Checkout/CheckoutService.cs
+++ b/src/VendlyServer.Application/Services/Checkout/CheckoutService.cs
@@ -128,14 +128,15 @@ public class CheckoutService(
         {
             order.Payment.Status = PaymentStatus.Paid;
             order.Payment.PaidAt = DateTime.UtcNow;
-            order.Status = OrderStatus.Accepted;
+            order.Status = OrderStatus.Payed;
             order.StatusHistory.Add(new OrderStatusHistory
             {
-                Status = OrderStatus.Accepted,
+                Status = OrderStatus.Payed,
                 Note = "Payment confirmed via Hamkorbank"
             });
 
-            await ClearCartAsync(order.UserId, cancellationToken);
+            // Order o'z cartiga ega (allaqachon checked-out) — to'lovdan keyin u faqat status bo'yicha
+            // bloklanadi. Foydalanuvchining keyingi open carti talab bo'yicha yangidan yaratiladi.
         }
         else if (state is HamkorPaymentState.Canceled)
         {
@@ -164,16 +165,6 @@ public class CheckoutService(
 
         var paymentStatus = order.Payment?.Status.ToString() ?? PaymentStatus.Pending.ToString();
         return new CheckoutStatusResponse(order.OrderNumber, paymentStatus, order.Status.ToString());
-    }
-
-    private async Task ClearCartAsync(long userId, CancellationToken cancellationToken)
-    {
-        var cartItems = await dbContext.CartItems
-            .Where(i => i.Cart.UserId == userId && !i.IsDeleted)
-            .ToListAsync(cancellationToken);
-
-        foreach (var item in cartItems)
-            item.IsDeleted = true;
     }
 
     // Try the IANA id first (Linux containers), fall back to the Windows id, then to a fixed UTC+5 offset.

--- a/src/VendlyServer.Application/Services/Orders/IOrderService.cs
+++ b/src/VendlyServer.Application/Services/Orders/IOrderService.cs
@@ -8,8 +8,8 @@ public interface IOrderService
     // Customer — checkout flow
     Task<Result<CreateOrderResponse>> CreateDraftAsync(long userId, CreateOrderRequest request, CancellationToken cancellationToken = default);
     Task<Result> SetAddressAsync(long userId, long id, SetOrderAddressRequest request, CancellationToken cancellationToken = default);
-    Task<Result<CreateOrderResponse>> GetMyDraftAsync(long userId, CancellationToken cancellationToken = default);
-    Task<Result> CancelMyDraftAsync(long userId, CancellationToken cancellationToken = default);
+    Task<Result<List<OrderListItemResponse>>> GetActiveOrdersAsync(long userId, CancellationToken cancellationToken = default);
+    Task<Result> CancelDraftAsync(long userId, long orderId, CancellationToken cancellationToken = default);
 
     // Customer — read
     Task<Result<List<OrderListItemResponse>>> GetMyOrdersAsync(long userId, OrderFilterRequest filter, CancellationToken cancellationToken = default);

--- a/src/VendlyServer.Application/Services/Orders/OrderErrors.cs
+++ b/src/VendlyServer.Application/Services/Orders/OrderErrors.cs
@@ -14,5 +14,7 @@ public static class OrderErrors
     public static readonly Error CartEmpty = Error.Validation("Order.CartEmpty", "Cart is empty.");
     public static readonly Error AddressNotFound = Error.NotFound("Order.AddressNotFound");
     public static readonly Error NotDraft = Error.Validation("Order.NotDraft", "Order is not in draft status.");
+    public static readonly Error ActiveOrderExists = Error.Conflict("Order.ActiveOrderExists");
+    public static readonly Error NotEditable = Error.Conflict("Order.NotEditable");
     public static readonly Error PaymentFailed = Error.Failure("Order.PaymentFailed");
 }

--- a/src/VendlyServer.Application/Services/Orders/OrderItemSync.cs
+++ b/src/VendlyServer.Application/Services/Orders/OrderItemSync.cs
@@ -1,0 +1,44 @@
+using VendlyServer.Application.Services.Pricing;
+using VendlyServer.Domain.Entities.Orders;
+
+namespace VendlyServer.Application.Services.Orders;
+
+// Order item snapshotlarini cart bilan moslaydi: eski itemlarni soft-delete qiladi,
+// cartdagi itemlardan qayta quradi (so'm narx bilan) va Subtotal/TotalAmount ni qayta hisoblaydi.
+// Create va cart-edit (re-sync) da bir xil ishlatiladi.
+public static class OrderItemSync
+{
+    // Mirrors the frontend DELIVERY_COST constant; move to delivery calculation/config later.
+    public const decimal DeliveryCost = 10m;
+
+    public static void Apply(Order order, IEnumerable<CartItem> cartItems, PricingContext pricing)
+    {
+        foreach (var existing in order.Items.Where(i => !i.IsDeleted))
+            existing.IsDeleted = true;
+
+        decimal subtotal = 0;
+
+        foreach (var item in cartItems.Where(i => !i.IsDeleted))
+        {
+            var variant = item.ProductVariant;
+            var unitPrice = pricing.CalculateSoumPrice(variant.Price, variant.Product.CategoryId);
+
+            order.Items.Add(new OrderItem
+            {
+                ProductId = variant.ProductId,
+                ProductNameSnap = variant.Product.Name.Uz ?? variant.Product.Name.Ru ?? string.Empty,
+                SkuSnap = string.IsNullOrWhiteSpace(variant.Name) ? $"VAR-{variant.Id}" : variant.Name,
+                ImageSnap = variant.Images.FirstOrDefault() ?? string.Empty,
+                WeightKgSnap = variant.Measurements?.WeightKg ?? 0,
+                Qty = item.Qty,
+                PriceSnap = unitPrice,
+                TotalSnap = unitPrice * item.Qty,
+            });
+
+            subtotal += unitPrice * item.Qty;
+        }
+
+        order.Subtotal = subtotal;
+        order.TotalAmount = subtotal + DeliveryCost;
+    }
+}

--- a/src/VendlyServer.Application/Services/Orders/OrderService.cs
+++ b/src/VendlyServer.Application/Services/Orders/OrderService.cs
@@ -14,9 +14,6 @@ public class OrderService(
     IOrderShippingService shippingService,
     IProductPricingService pricingService) : IOrderService
 {
-    // Mirrors the frontend DELIVERY_COST constant; move to delivery calculation/config later.
-    private const decimal DeliveryCost = 10m;
-
     // ── Customer — checkout flow ──────────────────────────────────────────────
 
     public async Task<Result<CreateOrderResponse>> CreateDraftAsync(
@@ -29,94 +26,43 @@ public class OrderService(
 
         if (address is null) return OrderErrors.AddressNotFound;
 
+        // Bir vaqtda faqat bitta to'lanmagan (Draft/New) order — yangisini yaratish uchun
+        // avvalgisi kamida Payed bo'lishi kerak.
+        var hasUnpaidOrder = await dbContext.Orders.AnyAsync(
+            o => o.UserId == userId && !o.IsDeleted &&
+                 (o.Status == OrderStatus.Draft || o.Status == OrderStatus.New),
+            cancellationToken);
+
+        if (hasUnpaidOrder) return OrderErrors.ActiveOrderExists;
+
+        // Open cart (hali orderga biriktirilmagan)
         var cart = await dbContext.Carts
-            .Where(c => c.UserId == userId && !c.IsDeleted)
+            .Where(c => c.UserId == userId && !c.IsDeleted && !c.IsCheckedOut)
             .Include(c => c.Items.Where(i => !i.IsDeleted))
                 .ThenInclude(i => i.ProductVariant)
                     .ThenInclude(v => v.Product)
             .Include(c => c.Items.Where(i => !i.IsDeleted))
                 .ThenInclude(i => i.ProductVariant)
                     .ThenInclude(v => v.Measurements)
-            .SingleOrDefaultAsync(cancellationToken);
+            .OrderBy(c => c.CreatedAt)
+            .FirstOrDefaultAsync(cancellationToken);
 
         var items = cart?.Items.Where(i => !i.IsDeleted).ToList() ?? [];
-        if (items.Count == 0) return OrderErrors.CartEmpty;
+        if (cart is null || items.Count == 0) return OrderErrors.CartEmpty;
 
         // Money path — USD rate / category narx mavjud bo'lmasa checkout to'xtaydi (raw fallback YO'Q).
         var pricingResult = await pricingService.CreateContextAsync(cancellationToken);
         if (!pricingResult.IsSuccess) return pricingResult.Error;
         var pricing = pricingResult.Data!;
 
-        // Cart ga allaqachon Draft/New order bog'langan bo'lsa — yangisini yaratmasdan davom etamiz.
-        if (cart is not null)
-        {
-            var existing = await dbContext.Orders
-                .Where(o => o.CartId == cart.Id &&
-                            (o.Status == OrderStatus.Draft || o.Status == OrderStatus.New) &&
-                            !o.IsDeleted)
-                .Select(o => new { o.Id, o.OrderNumber })
-                .FirstOrDefaultAsync(cancellationToken);
-
-            if (existing is not null)
-            {
-                var activeOrder = await dbContext.Orders
-                    .Where(o => o.Id == existing.Id)
-                    .Include(o => o.Items.Where(i => !i.IsDeleted))
-                    .SingleAsync(cancellationToken);
-
-                activeOrder.DeliveryCity        = address.City;
-                activeOrder.DeliveryDistrict    = address.District;
-                activeOrder.DeliveryStreet      = address.Street;
-                activeOrder.DeliveryHouse       = address.House;
-                activeOrder.DeliveryExtra       = address.Extra;
-                activeOrder.DeliveryBtsCityCode = address.BtsCityCode;
-
-                // Cart da o'zgargan itemlarni orderga sync qilamiz
-                foreach (var oi in activeOrder.Items)
-                    oi.IsDeleted = true;
-
-                foreach (var item in items)
-                {
-                    var variant = item.ProductVariant;
-                    var unitPrice = pricing.CalculateSoumPrice(variant.Price, variant.Product.CategoryId);
-                    activeOrder.Items.Add(new OrderItem
-                    {
-                        ProductId       = variant.ProductId,
-                        ProductNameSnap = variant.Product.Name.Uz ?? variant.Product.Name.Ru ?? string.Empty,
-                        SkuSnap         = string.IsNullOrWhiteSpace(variant.Name) ? $"VAR-{variant.Id}" : variant.Name,
-                        ImageSnap       = variant.Images.FirstOrDefault() ?? string.Empty,
-                        WeightKgSnap    = variant.Measurements?.WeightKg ?? 0,
-                        Qty             = item.Qty,
-                        PriceSnap       = unitPrice,
-                        TotalSnap       = unitPrice * item.Qty,
-                    });
-                }
-
-                var newSubtotal         = items.Sum(i =>
-                    pricing.CalculateSoumPrice(i.ProductVariant.Price, i.ProductVariant.Product.CategoryId) * i.Qty);
-                activeOrder.Subtotal    = newSubtotal;
-                activeOrder.TotalAmount = newSubtotal + DeliveryCost;
-
-                await dbContext.SaveChangesAsync(cancellationToken);
-                return new CreateOrderResponse(existing.Id, existing.OrderNumber);
-            }
-        }
-
-        var subtotal = items.Sum(i =>
-            pricing.CalculateSoumPrice(i.ProductVariant.Price, i.ProductVariant.Product.CategoryId) * i.Qty);
-        var totalAmount = subtotal + DeliveryCost;
-        var orderNumber = GenerateOrderNumber();
-
         var order = new Order
         {
             UserId = userId,
-            OrderNumber = orderNumber,
+            OrderNumber = GenerateOrderNumber(),
             Status = OrderStatus.Draft,
-            CartId = cart?.Id,
-            Subtotal = subtotal,
-            DeliveryCost = DeliveryCost,
+            CartId = cart.Id,
+            DeliveryCost = OrderItemSync.DeliveryCost,
             DiscountAmount = 0,
-            TotalAmount = totalAmount,
             DeliveryCity = address.City,
             DeliveryDistrict = address.District,
             DeliveryStreet = address.Street,
@@ -125,24 +71,11 @@ public class OrderService(
             DeliveryBtsCityCode = address.BtsCityCode,
         };
 
-        foreach (var item in items)
-        {
-            var variant = item.ProductVariant;
-            var unitPrice = pricing.CalculateSoumPrice(variant.Price, variant.Product.CategoryId);
-            order.Items.Add(new OrderItem
-            {
-                ProductId = variant.ProductId,
-                ProductNameSnap = variant.Product.Name.Uz ?? variant.Product.Name.Ru ?? string.Empty,
-                SkuSnap = string.IsNullOrWhiteSpace(variant.Name) ? $"VAR-{variant.Id}" : variant.Name,
-                ImageSnap = variant.Images.FirstOrDefault() ?? string.Empty,
-                WeightKgSnap = variant.Measurements?.WeightKg ?? 0,
-                Qty = item.Qty,
-                PriceSnap = unitPrice,
-                TotalSnap = unitPrice * item.Qty,
-            });
-        }
-
+        OrderItemSync.Apply(order, items, pricing);
         order.StatusHistory.Add(new OrderStatusHistory { Status = OrderStatus.Draft });
+
+        // Cart endi shu orderga biriktirildi → keyingi GET /api/carts yangi bo'sh savat yaratadi.
+        cart.IsCheckedOut = true;
 
         dbContext.Orders.Add(order);
         await dbContext.SaveChangesAsync(cancellationToken);
@@ -150,43 +83,33 @@ public class OrderService(
         return new CreateOrderResponse(order.Id, order.OrderNumber);
     }
 
-    public async Task<Result<CreateOrderResponse>> GetMyDraftAsync(
+    // Foydalanuvchining barcha "active" (terminal bo'lmagan) orderlari: Draft/New + bajarilayotganlar.
+    public async Task<Result<List<OrderListItemResponse>>> GetActiveOrdersAsync(
         long userId, CancellationToken cancellationToken = default)
     {
-        var cart = await dbContext.Carts
+        var active = new[]
+        {
+            OrderStatus.Draft, OrderStatus.New, OrderStatus.Payed, OrderStatus.Preparing,
+            OrderStatus.Shipped, OrderStatus.InTransit, OrderStatus.OutForDelivery,
+        };
+
+        var orders = await dbContext.Orders
             .AsNoTracking()
-            .Where(c => c.UserId == userId && !c.IsDeleted)
-            .SingleOrDefaultAsync(cancellationToken);
+            .Where(o => o.UserId == userId && !o.IsDeleted && active.Contains(o.Status))
+            .OrderByDescending(o => o.CreatedAt)
+            .Include(o => o.Items.Where(i => !i.IsDeleted))
+            .Include(o => o.Payment)
+            .ToListAsync(cancellationToken);
 
-        if (cart is null) return OrderErrors.NotFound;
-
-        var existing = await dbContext.Orders
-            .AsNoTracking()
-            .Where(o => o.CartId == cart.Id &&
-                        (o.Status == OrderStatus.Draft || o.Status == OrderStatus.New) &&
-                        !o.IsDeleted)
-            .Select(o => new { o.Id, o.OrderNumber })
-            .FirstOrDefaultAsync(cancellationToken);
-
-        return existing is null
-            ? OrderErrors.NotFound
-            : new CreateOrderResponse(existing.Id, existing.OrderNumber);
+        return orders.Select(o => MapToListItem(o, includeCustomer: false)).ToList();
     }
 
-    public async Task<Result> CancelMyDraftAsync(
-        long userId, CancellationToken cancellationToken = default)
+    public async Task<Result> CancelDraftAsync(
+        long userId, long orderId, CancellationToken cancellationToken = default)
     {
-        var cart = await dbContext.Carts
-            .AsNoTracking()
-            .Where(c => c.UserId == userId && !c.IsDeleted)
-            .SingleOrDefaultAsync(cancellationToken);
-
-        if (cart is null) return OrderErrors.NotFound;
-
         var order = await dbContext.Orders
-            .Where(o => o.CartId == cart.Id &&
-                        o.Status == OrderStatus.Draft &&
-                        !o.IsDeleted)
+            .Where(o => o.Id == orderId && o.UserId == userId && !o.IsDeleted &&
+                        (o.Status == OrderStatus.Draft || o.Status == OrderStatus.New))
             .SingleOrDefaultAsync(cancellationToken);
 
         if (order is null) return OrderErrors.NotFound;

--- a/src/VendlyServer.Application/Services/Orders/OrderStatusTransitions.cs
+++ b/src/VendlyServer.Application/Services/Orders/OrderStatusTransitions.cs
@@ -12,7 +12,7 @@ public static class OrderStatusTransitions
 {
     private static readonly Dictionary<OrderStatus, OrderStatus[]> Allowed = new()
     {
-        [OrderStatus.Accepted] = [OrderStatus.Preparing],
+        [OrderStatus.Payed] = [OrderStatus.Preparing],
         [OrderStatus.Preparing] = [OrderStatus.Shipped],
         [OrderStatus.Shipped] = [OrderStatus.InTransit],
         [OrderStatus.InTransit] = [OrderStatus.OutForDelivery],
@@ -23,7 +23,7 @@ public static class OrderStatusTransitions
     [
         OrderStatus.Draft,
         OrderStatus.New,
-        OrderStatus.Accepted,
+        OrderStatus.Payed,
         OrderStatus.Preparing,
         OrderStatus.Shipped,
         OrderStatus.InTransit,

--- a/src/VendlyServer.Domain/Entities/Orders/Cart.cs
+++ b/src/VendlyServer.Domain/Entities/Orders/Cart.cs
@@ -9,6 +9,9 @@ public class Cart : AuditableModelBase<long>
 {
     public long UserId { get; set; }
 
+    // false = open shopping cart; true = attached to an order
+    public bool IsCheckedOut { get; set; }
+
     [ForeignKey(nameof(UserId))]
     public User User { get; set; } = null!;
 

--- a/src/VendlyServer.Domain/Enums/OrderStatus.cs
+++ b/src/VendlyServer.Domain/Enums/OrderStatus.cs
@@ -2,7 +2,7 @@ namespace VendlyServer.Domain.Enums;
 
 // Draft(-1) → checkout boshlanganda
 // New(0)   → Hamkor payment initiated
-// Accepted(1) → Hamkor webhook: payment confirmed
+// Payed(1) → Hamkor webhook: payment confirmed
 // Preparing(3) → admin qo'lda
 // Shipped(4)   → admin: BTS ga jo'natildi
 // InTransit(5) / OutForDelivery(6) / Delivered(7) → BTS webhook
@@ -12,14 +12,13 @@ public enum OrderStatus
 {
     Draft          = -1,
     New            = 0,
-    Accepted       = 1,
-    Payed          = 2,
-    Preparing      = 3,
-    Shipped        = 4,
-    InTransit      = 5,
-    OutForDelivery = 6, 
-    Delivered      = 7,
-    Cancelled      = 8,
-    ReturnRequested= 9,
-    Returned       = 10,
+    Payed          = 5,
+    Preparing      = 10,
+    Shipped        = 15,
+    InTransit      = 20,
+    OutForDelivery = 25, 
+    Delivered      = 30,
+    Cancelled      = 35,
+    ReturnRequested= 40,
+    Returned       = 45,
 }

--- a/src/VendlyServer.Infrastructure/Persistence/Migrations/20260611190423_Add_Cart_IsCheckedOut.Designer.cs
+++ b/src/VendlyServer.Infrastructure/Persistence/Migrations/20260611190423_Add_Cart_IsCheckedOut.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using VendlyServer.Infrastructure.Persistence;
@@ -12,9 +13,11 @@ using VendlyServer.Infrastructure.Persistence;
 namespace VendlyServer.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260611190423_Add_Cart_IsCheckedOut")]
+    partial class Add_Cart_IsCheckedOut
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/VendlyServer.Infrastructure/Persistence/Migrations/20260611190423_Add_Cart_IsCheckedOut.cs
+++ b/src/VendlyServer.Infrastructure/Persistence/Migrations/20260611190423_Add_Cart_IsCheckedOut.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VendlyServer.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_Cart_IsCheckedOut : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "is_checked_out",
+                schema: "orders",
+                table: "carts",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "is_checked_out",
+                schema: "orders",
+                table: "carts");
+        }
+    }
+}


### PR DESCRIPTION
- OrderStatus: drop Accepted, renumber; Payed is now the paid status
- Cart editable while order is Draft/New; cart lock removed
- Each order owns its cart (Cart.IsCheckedOut); editing a draft's cart re-syncs its items/totals; New reverts to Draft on edit
- At most one unpaid (Draft/New) order per user; creating another requires the previous to be at least Payed
- Create new orders freely after payment
- OrderItemSync shared snapshot/re-sync helper
- Endpoints: GET /api/orders/active, DELETE /api/orders/{id} (replace /draft); checkout no longer clears the cart
- Migration: carts.is_checked_out