### PR TITLE
Fix #78: Allow unsetting IsDefault in AddressService.UpdateAsync

### DIFF
--- a/src/VendlyServer.Application/Services/Addresses/AddressService.cs
+++ b/src/VendlyServer.Application/Services/Addresses/AddressService.cs
@@ -146,7 +146,7 @@ public class AddressService(AppDbContext dbContext) : IAddressService
         address.House = request.House;
         address.Extra = request.Extra;
         address.BtsCityCode = request.BtsCityCode;
-        address.IsDefault = request.IsDefault || address.IsDefault;
+        address.IsDefault = request.IsDefault;
 
         await dbContext.SaveChangesAsync(cancellationToken);
 


### PR DESCRIPTION
## Summary

Fixes a one-way ratchet bug where setting `IsDefault: false` on a default address was silently ignored.

- **Root cause**: `address.IsDefault = request.IsDefault || address.IsDefault;` — the `||` means a currently-default address can never be un-defaulted via `UpdateAsync`
- **Fix**: Replace with a direct assignment `address.IsDefault = request.IsDefault;`
- The existing guard (lines 132–140) that clears other defaults when promoting an address is preserved and still correct

**Before:** Clients sending `IsDefault: false` receive HTTP 200 with `IsDefault` still `true` in the response — silent data loss.  
**After:** `IsDefault` reflects exactly what the client requested.

## Files Changed

- `src/VendlyServer.Application/Services/Addresses/AddressService.cs` — line 149, one-character change

## Verification

`dotnet build` could not be run in this environment (dotnet CLI unavailable). The change is a single-line assignment with no new dependencies or structural changes.

Related: This issue was also filed as #102. Existing open PRs #103, #109, #159 address #102 but are stale (based on old dev). This PR is a fresh, minimal fix based on current dev.

## Remaining Risks / Assumptions

- Allowing an address to have `IsDefault: false` when it is the only address is now permitted. If the product requires exactly one default address at all times, add a validator — but this was not specified in the issue and no other code enforces it.

Fixes #78

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7ocRmGggZgx28arEXwmBR)_