### PR TITLE
Fix #74: Set explicit 30s timeout on Smartup HTTP client

### DIFF
--- a/src/VendlyServer.Infrastructure/Dependencies.cs
+++ b/src/VendlyServer.Infrastructure/Dependencies.cs
@@ -71,7 +71,10 @@ public static class Dependencies
     private static IServiceCollection ConfigureSmartup(this IServiceCollection services)
     {
         services.ConfigureOptions<SmartupOptionsSetup>();
-        services.AddHttpClient("Smartup");
+        services.AddHttpClient("Smartup", client =>
+        {
+            client.Timeout = TimeSpan.FromSeconds(30);
+        });
         services.AddSingleton<ISmartupBroker, SmartupBroker>();
 
         return services;


### PR DESCRIPTION
## Summary

The Smartup named HTTP client was registered with no timeout, defaulting to `HttpClient`'s built-in 100-second limit. The nightly sync job makes dozens of HTTP calls (one for categories + one per page per category). A single hung Smartup API response could block a Hangfire worker thread for up to 100 seconds; across a multi-page sync, this compounds to potentially hours, starving all other background jobs.

**Fix**: Set `client.Timeout = TimeSpan.FromSeconds(30)` when configuring the named client.

## Files Changed

- `src/VendlyServer.Infrastructure/Dependencies.cs` — `ConfigureSmartup`, +3 lines

## Verification

`dotnet build` could not be run in this environment (dotnet CLI unavailable). The change is purely configuration-level — no logic changes — and matches the pattern used for other HTTP clients in the same file.

## Remaining Risks / Assumptions

- 30 seconds is a reasonable bound for a catalog API endpoint; adjust if Smartup's SLA requires longer. The key invariant is that it must be less than 100 s (the default) to provide meaningful protection.
- `OperationCanceledException` will be thrown on timeout; this is caught by `SmartupBroker.PostAsync`'s generic `catch` and converted to a failure result — existing behaviour.

Fixes #74

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7ocRmGggZgx28arEXwmBR)_