### PR TITLE
Fix #75: Cap SmartupSync pagination loop at 500 pages

### DIFF
--- a/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
+++ b/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
@@ -182,6 +182,8 @@ public class SmartupSyncService(
         var totalErrors = 0;
         var details = new List<object>();
 
+        const int MaxPages = 500;
+
         foreach (var cat in categories)
         {
             if (!categoryIdMap.TryGetValue(cat.ProductTypeId, out var categoryId))
@@ -208,7 +210,18 @@ public class SmartupSyncService(
                 }
 
                 var envelope = call.Result.Data!;
-                pageCount = envelope.GetPageCount();
+
+                if (page == 1)
+                {
+                    pageCount = envelope.GetPageCount();
+                    if (pageCount > MaxPages)
+                    {
+                        logger.LogWarning(
+                            "Smartup Sync [{LogId}]: category {TypeId} reports {Pages} pages — capping at {Max}",
+                            logId, cat.ProductTypeId, pageCount, MaxPages);
+                        pageCount = MaxPages;
+                    }
+                }
 
                 var (c, u) = await UpsertProductsAsync(envelope.Products, categoryId, cancellationToken);
                 catCreated += c;


### PR DESCRIPTION
## Summary

The Smartup product sync loop derived its page count from the external API response on every iteration. A malformed or malicious response reporting `pageCount = 10000` would trigger 10,000 HTTP calls and 10,000 `SaveChangesAsync` batches, monopolising the Hangfire worker for hours and exhausting Smartup's rate limits.

**Two changes:**
1. `pageCount` is now captured only from the **first page** response (not refreshed on every iteration), preventing mid-loop inflation.
2. `pageCount` is **capped at 500** with a warning log if exceeded. 500 pages × ~30 products/page = 15,000 products per category — well above realistic catalog sizes.

## Files Changed

- `src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs` — `SyncProductsAsync`, +16 lines

## Verification

`dotnet build` could not be run in this environment (dotnet CLI unavailable). The logic change is confined to the pagination header of the `do...while` loop; the actual upsert and result accumulation are unchanged.

## Remaining Risks / Assumptions

- If a real Smartup catalog legitimately exceeds 500 pages, the sync will be partial and a warning will be logged. Adjust `MaxPages` if needed. The current value is intentionally conservative.
- No migration or infrastructure changes required.

Fixes #75

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7ocRmGggZgx28arEXwmBR)_