### PR TITLE
Fix #205: add IsActive filter to GetByIdAsync and remove BCL UnauthorizedAccessException → 401 mapping

### DIFF
--- a/src/VendlyServer.Api/Middlewares/GlobalExceptionHandlerMiddleware.cs
+++ b/src/VendlyServer.Api/Middlewares/GlobalExceptionHandlerMiddleware.cs
@@ -13,11 +13,7 @@ public class GlobalExceptionHandlerMiddleware(ILogger<GlobalExceptionHandlerMidd
     {
         logger.LogError(exception, "Unhandled exception");
 
-        var (status, title) = exception switch
-        {
-            UnauthorizedAccessException => (StatusCodes.Status401Unauthorized, "Unauthorized"),
-            _ => (StatusCodes.Status500InternalServerError, "Internal Server Error")
-        };
+        var (status, title) = (StatusCodes.Status500InternalServerError, "Internal Server Error");
 
         var problemDetails = new ProblemDetails { Title = title, Status = status };
 

--- a/src/VendlyServer.Application/Services/Categories/CategoryService.cs
+++ b/src/VendlyServer.Application/Services/Categories/CategoryService.cs
@@ -29,7 +29,7 @@ public class CategoryService(
     {
         var category = await dbContext.Categories
             .AsNoTracking()
-            .Where(c => c.Id == id && !c.IsDeleted)
+            .Where(c => c.Id == id && !c.IsDeleted && c.IsActive)
             .Select(c => new CategoryResponse(
                 c.Id, c.Name, c.Slug, c.ImageUrl, c.IsActive,
                 c.Products.Count(p => !p.IsDeleted && p.IsActive),


### PR DESCRIPTION
Fixes #205

## Summary

Two warnings from the automated review (#205, 2026-06-13) are addressed in this PR.

### Warning 1 — `CategoryService.GetByIdAsync` returned inactive categories

`GetAllAsync` filters with `!c.IsDeleted && c.IsActive`, but `GetByIdAsync` only checked `!c.IsDeleted`, allowing deactivated categories to be fetched by direct ID. Added `&& c.IsActive` to the `Where` clause in `GetByIdAsync` to enforce the same visibility contract.

### Warning 2 — `GlobalExceptionHandlerMiddleware` mapped `UnauthorizedAccessException` to HTTP 401

`System.UnauthorizedAccessException` is a BCL dual-purpose exception: it signals auth denial in user code *and* is thrown by `File.ReadAllText`, `Directory.CreateDirectory`, and other I/O APIs on OS-level permission errors. Mapping it to 401 causes any I/O permission failure in the server to surface as a misleading auth error to clients and hides it from 5xx monitoring.

In this codebase, auth/authorization failures travel through the `Result` pattern (`Error.Unauthorized`) and never reach the exception handler as `UnauthorizedAccessException`. The switch case was removed; all unhandled exceptions now return 500.

## Files Changed

- `src/VendlyServer.Application/Services/Categories/CategoryService.cs` — `GetByIdAsync`: added `&& c.IsActive` to the `Where` predicate
- `src/VendlyServer.Api/Middlewares/GlobalExceptionHandlerMiddleware.cs` — removed `UnauthorizedAccessException → 401` case from the switch expression

## Verification

The .NET SDK is not available in this execution environment. Changes were verified by code review:
- Both edits are syntactically valid C# and follow the project's established patterns
- The `IsActive` guard mirrors the existing `GetAllAsync` predicate exactly
- The middleware simplification removes a 4-line switch and replaces it with a single tuple assignment; all other middleware behaviour is unchanged

## Risks / Assumptions

- **Warning 1**: If any admin tooling relies on `GET /api/categories/{id}` returning inactive categories (e.g. a CMS preview), it will now receive 404. A separate admin endpoint that omits `c.IsActive` (analogous to `GetAllAdminAsync` on `ProductService`) should be added if that use-case exists.
- **Warning 2**: No callers in the current codebase intentionally throw `UnauthorizedAccessException` for auth purposes (auth uses the Result pattern). If a future integration does throw it, it will now produce a 500 rather than a 401 — which is the correct behaviour for an unhandled exception.

https://claude.ai/code/session_01HCnJvYeUvaXsdLY3QjBpXE

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCnJvYeUvaXsdLY3QjBpXE)_