### PR TITLE
Fix #205: apply IsActive filter in CategoryService.GetByIdAsync; remove UnauthorizedAccessException→401 mapping

### DIFF
--- a/src/VendlyServer.Api/Middlewares/GlobalExceptionHandlerMiddleware.cs
+++ b/src/VendlyServer.Api/Middlewares/GlobalExceptionHandlerMiddleware.cs
@@ -15,7 +15,6 @@ public class GlobalExceptionHandlerMiddleware(ILogger<GlobalExceptionHandlerMidd
 
         var (status, title) = exception switch
         {
-            UnauthorizedAccessException => (StatusCodes.Status401Unauthorized, "Unauthorized"),
             _ => (StatusCodes.Status500InternalServerError, "Internal Server Error")
         };
 

--- a/src/VendlyServer.Application/Services/Categories/CategoryService.cs
+++ b/src/VendlyServer.Application/Services/Categories/CategoryService.cs
@@ -29,7 +29,7 @@ public class CategoryService(
     {
         var category = await dbContext.Categories
             .AsNoTracking()
-            .Where(c => c.Id == id && !c.IsDeleted)
+            .Where(c => c.Id == id && !c.IsDeleted && c.IsActive)
             .Select(c => new CategoryResponse(
                 c.Id, c.Name, c.Slug, c.ImageUrl, c.IsActive,
                 c.Products.Count(p => !p.IsDeleted && p.IsActive),

--- a/tests/VendlyServer.Tests/Services/CategoryServiceTests.cs
+++ b/tests/VendlyServer.Tests/Services/CategoryServiceTests.cs
@@ -88,6 +88,16 @@ public class CategoryServiceTests : IDisposable
         Assert.Equal(CategoryErrors.NotFound, result.Error);
     }
 
+    [Fact]
+    public async Task GetById_ReturnsNotFound_WhenInactive()
+    {
+        // Category 2 (Clothing) exists but IsActive = false — should not be visible via public GetById
+        var result = await _service.GetByIdAsync(2);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(CategoryErrors.NotFound, result.Error);
+    }
+
     // ── AddAsync ──────────────────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes #205

Two warnings from the automated review of commit `bc68a63` (2026-05-10), both now resolved:

### Fix 1 — `CategoryService.GetByIdAsync` now enforces `IsActive`

`GetByIdAsync` was missing the `IsActive` guard that `GetAllAsync` already applied. A category deactivated via `ToggleActiveAsync` would correctly disappear from `GET /api/categories` (list) but remain fully accessible via `GET /api/categories/{id}` (by-ID lookup). Any client holding a category ID from bookmarks or shareable URLs could retrieve the full `CategoryResponse` even after the category was intentionally hidden.

**Change:** Added `&& c.IsActive` to the `Where` predicate in `GetByIdAsync`, consistent with `GetAllAsync`.

```csharp
// Before
.Where(c => c.Id == id && !c.IsDeleted)

// After
.Where(c => c.Id == id && !c.IsDeleted && c.IsActive)
```

If an admin endpoint needs to access inactive categories, a separate `GetByIdAdminAsync` method should be added (analogous to the existing `GetAllAsync` / `GetAllAdminAsync` split on `ProductService`).

### Fix 2 — `GlobalExceptionHandlerMiddleware` no longer maps `UnauthorizedAccessException` to HTTP 401

`System.UnauthorizedAccessException` is thrown for two unrelated reasons in .NET:
1. Explicit auth denials in user code
2. OS-level file system permission errors (e.g., `File.ReadAllText`, `Directory.CreateDirectory`)

In this codebase, authorization failures already flow through the `Result` pattern (`Error.Unauthorized(...)`) and never reach the exception handler as an `UnauthorizedAccessException`. Keeping the mapping meant that any file system permission error encountered at runtime (wrong upload directory permissions, unwritable log path, etc.) would be returned to clients as `401 Unauthorized` instead of `500 Internal Server Error`, misleading clients and suppressing 5xx monitoring.

**Change:** Removed the `UnauthorizedAccessException` arm from the switch expression; the catch-all `_` → `500 Internal Server Error` now handles all unexpected exceptions.

## Files Changed

- `src/VendlyServer.Application/Services/Categories/CategoryService.cs` — added `&& c.IsActive` to `GetByIdAsync` WHERE predicate
- `src/VendlyServer.Api/Middlewares/GlobalExceptionHandlerMiddleware.cs` — removed `UnauthorizedAccessException → 401` case

## Verification

`dotnet` is not installed in the automated environment; build verification was not possible. The changes are syntactically trivial:
- Appending a boolean condition to an existing LINQ predicate
- Removing one arm from a switch expression

Both edits have been manually verified by inspection against the surrounding code patterns.

## Risks / Assumptions

- Any client that relied on receiving `401` for server-side I/O permission errors (and using that to trigger re-authentication) will now receive `500`. This is the correct behavior.
- If an admin endpoint that returns inactive categories is needed in the future, a separate `GetByIdAdminAsync` should be added rather than reverting this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRCgPD4uaMEmRtA85VFitX)_