### PR TITLE
Fix #185: validate ProductFilterRequest bounds; map ErrorType.Failure to HTTP 500

### DIFF
--- a/src/VendlyServer.Application/Services/Products/Contracts/ProductFilterRequest.cs
+++ b/src/VendlyServer.Application/Services/Products/Contracts/ProductFilterRequest.cs
@@ -1,8 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace VendlyServer.Application.Services.Products.Contracts;
 
 public record ProductFilterRequest
 {
+    [Range(1, int.MaxValue)]
     public int Page { get; init; } = 1;
+
+    [Range(1, 100)]
     public int PageSize { get; init; } = 20;
+
     public long? CategoryId { get; init; }
 }

--- a/src/VendlyServer.Infrastructure/Extensions/ResultExtensions.cs
+++ b/src/VendlyServer.Infrastructure/Extensions/ResultExtensions.cs
@@ -24,7 +24,7 @@ public static class ResultExtensions
         ErrorType.NotFound     => StatusCodes.Status404NotFound,
         ErrorType.Conflict     => StatusCodes.Status409Conflict,
         ErrorType.Unauthorized => StatusCodes.Status401Unauthorized,
-        _                      => StatusCodes.Status400BadRequest
+        _                      => StatusCodes.Status500InternalServerError
     };
 
     private static string GetTitle(ErrorType errorType) => errorType switch
@@ -33,6 +33,6 @@ public static class ResultExtensions
         ErrorType.NotFound     => "Not Found",
         ErrorType.Conflict     => "Conflict",
         ErrorType.Unauthorized => "Unauthorized",
-        _                      => "Bad Request"
+        _                      => "Internal Server Error"
     };
 }


### PR DESCRIPTION
## Summary

Fixes #185

Two medium findings from the automated review of commit `bc68a63` (2026-05-10):

---

### Fix 1 — `ProductFilterRequest`: add validation bounds for `Page` and `PageSize`

`GET /api/products` is `[AllowAnonymous]` and accepts `Page` and `PageSize` as query parameters. With no validation, an unauthenticated caller could:
- Supply `PageSize=1000000`, loading the entire product table into memory
- Supply `Page=-1`, causing `Skip((Page-1) * PageSize)` to compute a negative `OFFSET`, which EF Core passes to the database and throws a runtime exception

**Change:** Added `[Range]` data annotations to `ProductFilterRequest`. ASP.NET Core's model binding populates `ModelState` from these annotations; the existing `ModelValidationFilter` then rejects invalid requests with `400 Bad Request` before the service is called.

```csharp
[Range(1, int.MaxValue)]
public int Page { get; init; } = 1;

[Range(1, 100)]
public int PageSize { get; init; } = 20;
```

---

### Fix 2 — `ResultExtensions.GetStatusCode`: default case returns HTTP 500 for `ErrorType.Failure`

The default `_` arm in `GetStatusCode` was returning `StatusCodes.Status400BadRequest`. Since `ErrorType.Failure` is the only type that falls through to the default, this meant any server-side failure result (database errors, infrastructure failures, etc.) was returned to clients as `400 Bad Request` rather than `500 Internal Server Error`. Consequences:
- **Misleads clients**: a 400 tells clients to change their request; a 500 signals a transient server problem worth retrying
- **Suppresses 5xx monitoring**: alerting rules and dashboards watching 5xx counts would miss these errors entirely

**Change:** Default case now returns `500 Internal Server Error` with title `"Internal Server Error"`.

## Files Changed

- `src/VendlyServer.Application/Services/Products/Contracts/ProductFilterRequest.cs` — added `[Range]` attributes on `Page` and `PageSize`
- `src/VendlyServer.Infrastructure/Extensions/ResultExtensions.cs` — default `_` arm returns 500 / "Internal Server Error"

## Verification

`dotnet` is not installed in the automated environment. Both changes were verified by inspection:
- `ProductFilterRequest`: `[Range]` annotations are standard ASP.NET Core model validation; `ModelValidationFilter` already calls `context.ModelState.IsValid`
- `ResultExtensions`: the default arm was `StatusCodes.Status400BadRequest`; changed to `StatusCodes.Status500InternalServerError`

## Risks / Assumptions

- Any client currently expecting `400` for infrastructure failures will now receive `500`. This is correct behavior.
- The `[Range(1, 100)]` cap on `PageSize` may be too tight if there are admin scenarios requiring more results per page. If so, consider a separate admin-scoped `AdminProductFilterRequest` without the cap, consistent with the existing `GetAllAdminAsync` pattern (which ignores the filter entirely).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRCgPD4uaMEmRtA85VFitX)_