### PR TITLE
Fix #205: CategoryService IsActive guard + AuthenticationException for auth failures

### DIFF
--- a/src/VendlyServer.Api/Controllers/Common/AuthorizedController.cs
+++ b/src/VendlyServer.Api/Controllers/Common/AuthorizedController.cs
@@ -1,3 +1,4 @@
+using System.Security.Authentication;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
 using VendlyServer.Domain.Enums;
@@ -15,13 +16,13 @@ public abstract class AuthorizedController : ControllerBase
         get
         {
             var raw = HttpContext.User.FindFirstValue(CustomClaims.Id)
-                      ?? throw new UnauthorizedAccessException("Required claim not found");
+                      ?? throw new AuthenticationException("Required claim not found");
             return (long)Convert.ChangeType(raw, typeof(long));
         }
     }
 
     protected UserRole Role => Enum.Parse<UserRole>(
         HttpContext.User.FindFirstValue(CustomClaims.Role)
-            ?? throw new UnauthorizedAccessException("Role claim not found"),
+            ?? throw new AuthenticationException("Role claim not found"),
         ignoreCase: true);
 }

--- a/src/VendlyServer.Api/Middlewares/GlobalExceptionHandlerMiddleware.cs
+++ b/src/VendlyServer.Api/Middlewares/GlobalExceptionHandlerMiddleware.cs
@@ -1,3 +1,4 @@
+using System.Security.Authentication;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 
@@ -13,9 +14,12 @@ public class GlobalExceptionHandlerMiddleware(ILogger<GlobalExceptionHandlerMidd
     {
         logger.LogError(exception, "Unhandled exception");
 
+        // AuthenticationException is thrown by AuthorizedController when required JWT claims are missing.
+        // UnauthorizedAccessException is intentionally excluded here: it is also raised by I/O APIs on
+        // file system permission errors, so mapping it to 401 would mislead clients and hide 5xx failures.
         var (status, title) = exception switch
         {
-            UnauthorizedAccessException => (StatusCodes.Status401Unauthorized, "Unauthorized"),
+            AuthenticationException => (StatusCodes.Status401Unauthorized, "Unauthorized"),
             _ => (StatusCodes.Status500InternalServerError, "Internal Server Error")
         };
 

--- a/src/VendlyServer.Application/Services/Categories/CategoryService.cs
+++ b/src/VendlyServer.Application/Services/Categories/CategoryService.cs
@@ -29,7 +29,7 @@ public class CategoryService(
     {
         var category = await dbContext.Categories
             .AsNoTracking()
-            .Where(c => c.Id == id && !c.IsDeleted)
+            .Where(c => c.Id == id && !c.IsDeleted && c.IsActive)
             .Select(c => new CategoryResponse(
                 c.Id, c.Name, c.Slug, c.ImageUrl, c.IsActive,
                 c.Products.Count(p => !p.IsDeleted && p.IsActive),


### PR DESCRIPTION
## Summary

Fixes #205 — two warnings from the automated review on 2026-06-13.

### Warning 1: `CategoryService.GetByIdAsync` returns inactive categories

`GetAllAsync` already filters `c.IsActive`, but `GetByIdAsync` did not. An inactive category (e.g., deactivated by an admin or excluded by Smartup sync) was still accessible by direct ID, breaking the visibility contract.

**Fix:** added `&& c.IsActive` to the `Where` clause in `GetByIdAsync`.

### Warning 2: `GlobalExceptionHandlerMiddleware` mapped `UnauthorizedAccessException` to HTTP 401

`System.UnauthorizedAccessException` is also thrown by .NET I/O APIs on file system permission errors. Mapping it to 401 would mislead clients and hide 5xx infrastructure failures from monitoring.

The actual intentional auth throws (`AuthorizedController.UserId` / `Role`) were changed to `System.Security.Authentication.AuthenticationException`, which is semantically correct and I/O-safe. The middleware now catches `AuthenticationException` instead.

## Files Changed

- `src/VendlyServer.Application/Services/Categories/CategoryService.cs` — added `c.IsActive` to `GetByIdAsync` Where clause
- `src/VendlyServer.Api/Middlewares/GlobalExceptionHandlerMiddleware.cs` — changed exception catch from `UnauthorizedAccessException` to `AuthenticationException`
- `src/VendlyServer.Api/Controllers/Common/AuthorizedController.cs` — changed both `throw new UnauthorizedAccessException(...)` to `throw new AuthenticationException(...)`

## Verification

Build: `dotnet build`

## Risks / Assumptions

- `ToggleActiveAsync` and admin endpoints still use `!c.IsDeleted` only (no `IsActive` guard), consistent with the admin-vs-public split pattern seen in `ProductService`. No admin category endpoint was changed.
- `AuthenticationException` is in `System.Security.Authentication`, available in all .NET 6+ targets — no new package dependency needed.
- If any other code path throws `UnauthorizedAccessException` expecting a 401 response, it will now receive 500. A codebase-wide search confirms only `AuthorizedController` threw this exception intentionally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6Uy2L7W6nP92n3e21CbN1)_