### PR TITLE
Fix #192: re-throw OperationCanceledException in SmartupBroker.PostAsync

### DIFF
--- a/src/VendlyServer.Infrastructure/Brokers/Smartup/SmartupBroker.cs
+++ b/src/VendlyServer.Infrastructure/Brokers/Smartup/SmartupBroker.cs
@@ -100,6 +100,11 @@ public class SmartupBroker(
             var data = JsonSerializer.Deserialize<T>(rawJson);
             return (data, responseBody, true, (int)sw.ElapsedMilliseconds, startedAt, finishedAt);
         }
+        catch (OperationCanceledException)
+        {
+            sw.Stop();
+            throw;
+        }
         catch (Exception ex)
         {
             sw.Stop();


### PR DESCRIPTION
## Summary

Fixes #192 (Warning 1) — `SmartupBroker.PostAsync` was swallowing `OperationCanceledException` inside its generic `catch (Exception ex)` handler, preventing Hangfire from cleanly stopping in-progress sync jobs on shutdown or manual cancellation.

The cancellation was being converted to a failure `Result`, causing cancelled jobs to appear as errors in sync logs and preventing the Hangfire graceful shutdown loop from observing the cancellation signal.

**Fix:** added a dedicated `catch (OperationCanceledException)` before the generic handler that re-throws immediately after stopping the stopwatch, consistent with the pattern already used in `DownloadImageAsync`.

## Files Changed

- `src/VendlyServer.Infrastructure/Brokers/Smartup/SmartupBroker.cs` — added `catch (OperationCanceledException) { sw.Stop(); throw; }` before the generic exception handler in `PostAsync`

## Verification

Build: `dotnet build`

## Risks / Assumptions

- This change makes `PostAsync` propagate cancellation to its callers (`GetCategoriesAsync`, `GetProductsAsync`). Those methods do not catch exceptions, so cancellation will propagate through `SmartupSyncService` up to `SmartupCatalogSyncJob`, which Hangfire will observe as a clean job cancellation — the intended behavior.
- Warning 2 of issue #192 (concurrency guard for `SmartupCatalogSyncJob`) is a separate, larger change and is not addressed in this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6Uy2L7W6nP92n3e21CbN1)_