### PR TITLE
Fix #88: replace ContinueWith with await+LINQ in SyncCategoriesAsync

### DIFF
--- a/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
+++ b/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
@@ -157,12 +157,13 @@ public class SmartupSyncService(
         logger.LogInformation("Smartup Sync [{LogId}]: categories — +{Created} ~{Updated}",
             logId, created, updated);
 
-        var idMap = await dbContext.Categories
+        var freshCategories = await dbContext.Categories
             .Where(c => !c.IsDeleted && c.Metadata != null)
-            .ToListAsync(cancellationToken)
-            .ContinueWith(t => t.Result
-                .Where(c => TryGetSourceId(c.Metadata, out _))
-                .ToDictionary(c => GetSourceId(c.Metadata)!, c => c.Id));
+            .ToListAsync(cancellationToken);
+
+        var idMap = freshCategories
+            .Where(c => TryGetSourceId(c.Metadata, out _))
+            .ToDictionary(c => GetSourceId(c.Metadata)!, c => c.Id);
 
         return (idMap, created, updated);
     }


### PR DESCRIPTION
## Summary

Fixes #88

`SmartupSyncService.SyncCategoriesAsync` built the category ID map using `.ContinueWith()` chained onto an EF Core `ToListAsync` call:

```csharp
// Before
var idMap = await dbContext.Categories
    .Where(c => !c.IsDeleted && c.Metadata != null)
    .ToListAsync(cancellationToken)
    .ContinueWith(t => t.Result
        .Where(c => TryGetSourceId(c.Metadata, out _))
        .ToDictionary(c => GetSourceId(c.Metadata)!, c => c.Id));
```

When `cancellationToken` fires during `ToListAsync`, the continuation accesses `t.Result` on a cancelled task, which throws `AggregateException` (wrapping `OperationCanceledException`) instead of propagating `OperationCanceledException` directly. This breaks the standard .NET cancellation contract — Hangfire's graceful-shutdown retry logic and structured logging both expect `OperationCanceledException`, not `AggregateException`.

## Fix

Separate the `await` from the in-memory LINQ projection:

```csharp
// After
var freshCategories = await dbContext.Categories
    .Where(c => !c.IsDeleted && c.Metadata != null)
    .ToListAsync(cancellationToken);

var idMap = freshCategories
    .Where(c => TryGetSourceId(c.Metadata, out _))
    .ToDictionary(c => GetSourceId(c.Metadata)!, c => c.Id);
```

Logic is identical on the happy path. On cancellation, `OperationCanceledException` now propagates cleanly up the call stack to Hangfire.

## Files Changed

- `src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs` — split `ContinueWith` into two-step await + LINQ (lines 160-166)

## Verification

`dotnet` was not available in the automated run environment, so a local build could not be executed. The change is a pure refactor: same input type (`List<Category>` from `ToListAsync`), same output type (`Dictionary<string, long>`), same predicate and key selector. No new dependencies or API surface changes.

## Risks / Assumptions

- No semantic change to the happy path: the query, filter, and dictionary construction are unchanged.
- The fix is scoped to one method. No other `ContinueWith` calls were found in this service.
- Assumes dotnet's standard behaviour: awaiting `ToListAsync` directly propagates `OperationCanceledException` from EF Core when the token is cancelled, which is the documented contract.


---
_Generated by [Claude Code](https://claude.ai/code/session_016X8Lqmx9LyRwnHdUpchBfK)_