### PR TITLE
Fix #205: add IsActive filter to CategoryService.GetByIdAsync; fix UnauthorizedAccessException mapping

### DIFF
--- a/src/VendlyServer.Api/Middlewares/GlobalExceptionHandlerMiddleware.cs
+++ b/src/VendlyServer.Api/Middlewares/GlobalExceptionHandlerMiddleware.cs
@@ -13,15 +13,13 @@ public class GlobalExceptionHandlerMiddleware(ILogger<GlobalExceptionHandlerMidd
     {
         logger.LogError(exception, "Unhandled exception");
 
-        var (status, title) = exception switch
+        var problemDetails = new ProblemDetails
         {
-            UnauthorizedAccessException => (StatusCodes.Status401Unauthorized, "Unauthorized"),
-            _ => (StatusCodes.Status500InternalServerError, "Internal Server Error")
+            Title = "Internal Server Error",
+            Status = StatusCodes.Status500InternalServerError
         };
 
-        var problemDetails = new ProblemDetails { Title = title, Status = status };
-
-        httpContext.Response.StatusCode = status;
+        httpContext.Response.StatusCode = StatusCodes.Status500InternalServerError;
         await httpContext.Response.WriteAsJsonAsync(problemDetails, cancellationToken);
         return true;
     }

--- a/src/VendlyServer.Application/Services/Categories/CategoryService.cs
+++ b/src/VendlyServer.Application/Services/Categories/CategoryService.cs
@@ -29,7 +29,7 @@ public class CategoryService(
     {
         var category = await dbContext.Categories
             .AsNoTracking()
-            .Where(c => c.Id == id && !c.IsDeleted)
+            .Where(c => c.Id == id && !c.IsDeleted && c.IsActive)
             .Select(c => new CategoryResponse(
                 c.Id, c.Name, c.Slug, c.ImageUrl, c.IsActive,
                 c.Products.Count(p => !p.IsDeleted && p.IsActive),


### PR DESCRIPTION
## Summary

Fixes #205

Two warning-level correctness fixes from the automated review run of 2026-06-13:

### 1. `CategoryService.GetByIdAsync` — add `IsActive` filter

`GetByIdAsync` was missing the `c.IsActive` guard that `GetAllAsync` already applies. A deactivated category was invisible in list endpoints but still fully retrievable by ID.

**File changed:** `src/VendlyServer.Application/Services/Categories/CategoryService.cs`

**Change:** Added `&& c.IsActive` to the `.Where(...)` predicate in `GetByIdAsync`, making it consistent with `GetAllAsync`.

If an admin endpoint needs to retrieve inactive categories, a separate `GetByIdAdminAsync` method (analogous to the `GetAllAsync` / `GetAllAdminAsync` split on `ProductService`) should be added in a follow-up.

### 2. `GlobalExceptionHandlerMiddleware` — remove `UnauthorizedAccessException → 401` mapping

`System.UnauthorizedAccessException` is thrown by both intentional auth-denial code _and_ OS-level I/O permission errors (e.g., `File.ReadAllText` on a file the process cannot read). Mapping it to HTTP 401 means a server-side infrastructure failure (wrong file permissions on an upload directory, unwritable log file, etc.) would silently appear to the client as an authentication error, masking the real 5xx failure.

In this codebase, authorization failures are handled via the `Result` pattern and never reach the exception handler as `UnauthorizedAccessException`, so the case was removed entirely. The middleware now always returns 500 for unhandled exceptions.

**File changed:** `src/VendlyServer.Api/Middlewares/GlobalExceptionHandlerMiddleware.cs`

---

## Files changed

- `src/VendlyServer.Application/Services/Categories/CategoryService.cs`
- `src/VendlyServer.Api/Middlewares/GlobalExceptionHandlerMiddleware.cs`

## Verification

`dotnet` is not available in this automated execution environment. Changes are minimal and targeted:
- A single `.Where()` predicate addition — no logic change beyond the filter.
- Removal of one switch arm from the exception handler — no new code paths introduced.

## Risks / Assumptions

- Any client currently fetching inactive categories by ID will start receiving 404. This is the intended behavior per the issue, but confirm this is acceptable for any existing client paths.
- If a future code path intentionally throws `UnauthorizedAccessException` for auth purposes, it will now surface as 500. Consider using a custom exception type or the existing `Result.Failure(Error.Unauthorized(...))` pattern instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CK2H1NXrhtQ7LZAzsqaAjF)_