### PR TITLE
Fix #192: re-throw OperationCanceledException in SmartupBroker; add DisableConcurrentExecution

### DIFF
--- a/src/VendlyServer.Application/Jobs/SmartupCatalog/SmartupCatalogSyncJob.cs
+++ b/src/VendlyServer.Application/Jobs/SmartupCatalog/SmartupCatalogSyncJob.cs
@@ -1,8 +1,10 @@
+using Hangfire;
 using Microsoft.Extensions.Logging;
 using VendlyServer.Application.Services.SmartupSync;
 
 namespace VendlyServer.Application.Jobs.SmartupCatalog;
 
+[DisableConcurrentExecution(timeoutInSeconds: 0)]
 public class SmartupCatalogSyncJob(
     ISmartupSyncService smartupSyncService,
     ILogger<SmartupCatalogSyncJob> logger) : ISmartupCatalogSyncJob

--- a/src/VendlyServer.Infrastructure/Brokers/Smartup/SmartupBroker.cs
+++ b/src/VendlyServer.Infrastructure/Brokers/Smartup/SmartupBroker.cs
@@ -100,6 +100,11 @@ public class SmartupBroker(
             var data = JsonSerializer.Deserialize<T>(rawJson);
             return (data, responseBody, true, (int)sw.ElapsedMilliseconds, startedAt, finishedAt);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            sw.Stop();
+            throw;
+        }
         catch (Exception ex)
         {
             sw.Stop();


### PR DESCRIPTION
## Summary

Fixes #192

Two warning-level fixes from the automated review run of 2026-06-11:

### 1. `SmartupBroker.PostAsync` — re-throw `OperationCanceledException`

The generic `catch (Exception ex)` block in `PostAsync` was swallowing `OperationCanceledException`, converting a clean cancellation (e.g., Hangfire shutdown) into a failure result. This caused:
- Hangfire's graceful shutdown to wait for all remaining sync pages to complete instead of stopping mid-loop.
- The sync log to record `SyncStatus.Partial` or `SyncStatus.Error` for an intentionally cancelled job.

Added a `catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)` block before the generic catch that re-throws, consistent with how `DownloadImageAsync` in the same class already handles this case.

**File changed:** `src/VendlyServer.Infrastructure/Brokers/Smartup/SmartupBroker.cs`

### 2. `SmartupCatalogSyncJob` — add `[DisableConcurrentExecution]`

With no concurrency guard, two concurrent sync runs (e.g., a manual trigger while the daily cron is running) would both read the same DB snapshot, both conclude that new categories don't exist, and both insert duplicate rows. Subsequent runs would compound the problem.

Added `[DisableConcurrentExecution(timeoutInSeconds: 0)]` from Hangfire so a second instance immediately aborts if one is already running. This is the lowest-effort fix; a DB-level unique constraint on the category source identifier is recommended as a belt-and-suspenders follow-up (tracked in #192).

**File changed:** `src/VendlyServer.Application/Jobs/SmartupCatalog/SmartupCatalogSyncJob.cs`

---

## Files changed

- `src/VendlyServer.Infrastructure/Brokers/Smartup/SmartupBroker.cs`
- `src/VendlyServer.Application/Jobs/SmartupCatalog/SmartupCatalogSyncJob.cs`

## Verification

`dotnet` is not available in this automated execution environment. Both changes are minimal and targeted:
- Re-throwing `OperationCanceledException` is a one-catch-block addition mirroring the existing pattern in `DownloadImageAsync`.
- `[DisableConcurrentExecution]` is a standard Hangfire attribute with no logic change.

## Risks / Assumptions

- `[DisableConcurrentExecution(timeoutInSeconds: 0)]` causes a concurrent job to fail immediately rather than wait. If a long-running sync is in progress and an admin triggers a second run, the second run will fail with a lock-acquisition error. This is preferable to creating duplicate data, but operators should be aware the trigger endpoint may return a failure during an active sync.
- A DB-level unique constraint on `Categories` source identifier is still recommended as follow-up (Option B from the issue).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CK2H1NXrhtQ7LZAzsqaAjF)_