### PR TITLE
Fix #212 #200 #169 #165: remove hardcoded secrets from all appsettings files

### DIFF
--- a/src/VendlyServer.Api/appsettings.Development.json
+++ b/src/VendlyServer.Api/appsettings.Development.json
@@ -13,8 +13,8 @@
   },
   "Hamkor": {
     "BaseUrl": "https://test-openapi.hamkorbank.uz",
-    "Key": "2w0M5cc9RRPSMcAeRNsdvKf_YFga",
-    "Secret": "UEwRqqTQhernbPR89M_PMAaUqg4a",
+    "Key": "",
+    "Secret": "",
     "CallbackBaseUrl": "https://REPLACE_WITH_NGROK_URL",
     "Tin": "310070597",
     "Spic": "08418001001002105",
@@ -42,7 +42,7 @@
     }
   },
   "Jwt": {
-    "SecretKey": "DevVendlySecretKeyasdqwe123dasdhtjdbnfkjasuid",
+    "SecretKey": "",
     "Issuer": "VendlyServer",
     "Audience": "VendlyClient",
     "ExpirationInMinutes": 120
@@ -50,7 +50,7 @@
   "Minio": {
     "Endpoint": "files.vestor.uz",
     "AccessKey": "vendlyadmin",
-    "SecretKey": "rI0eSKvglRFjLz0TxhrlBB5I0boruQnf",
+    "SecretKey": "",
     "BucketName": "stage-vendly",
     "PublicBaseUrl": "https://files.vestor.uz",
     "UseSsl": true
@@ -73,7 +73,7 @@
   },
   "TelegramBot": {
     "Enabled": false,
-    "Token": "8729785259:AAGZvxgnYzhylTPervZHS51iF44wboHBFdg",
+    "Token": "",
     "PublicBaseUrl": "https://stage-opto.vestor.uz",
     "MiniAppUrl": "https://vendly-client.vercel.app",
     "WebhookSecretToken": "MySecret",

--- a/src/VendlyServer.Api/appsettings.Production.json
+++ b/src/VendlyServer.Api/appsettings.Production.json
@@ -17,15 +17,15 @@
     ]
   },
   "ConnectionStrings": {
-    "DefaultConnectionString": "Host=host.docker.internal;Port=5432;Database=prod_vendly_db;Username=postgres;Password=K@3wF!8zQ2#eRt"
+    "DefaultConnectionString": "Host=host.docker.internal;Port=5432;Database=prod_vendly_db;Username=postgres;Password="
   },
   "Client": {
     "BaseUrl": "https://opto.vestor.uz"
   },
   "Hamkor": {
     "BaseUrl": "https://test-openapi.hamkorbank.uz",
-    "Key": "2w0M5cc9RRPSMcAeRNsdvKf_YFga",
-    "Secret": "UEwRqqTQhernbPR89M_PMAaUqg4a",
+    "Key": "",
+    "Secret": "",
     "CallbackBaseUrl": "https://api-opto.vestor.uz",
     "Tin": "310070597",
     "Spic": "08418001001002105",
@@ -53,7 +53,7 @@
     }
   },
   "Jwt": {
-    "SecretKey": "ProdVendlySecretKeyasdqwe123dasdhtjdbnfkjasuid",
+    "SecretKey": "",
     "Issuer": "VendlyServer",
     "Audience": "VendlyClient",
     "ExpirationInMinutes": 120
@@ -61,7 +61,7 @@
   "Minio": {
     "Endpoint": "minio:9000",
     "AccessKey": "vendlyadmin",
-    "SecretKey": "rI0eSKvglRFjLz0TxhrlBB5I0boruQnf",
+    "SecretKey": "",
     "BucketName": "prod-vendly",
     "PublicBaseUrl": "https://files.vestor.uz",
     "UseSsl": false
@@ -73,7 +73,7 @@
   },
   "TelegramBot": {
     "Enabled": false,
-    "Token": "8729785259:AAGZvxgnYzhylTPervZHS51iF44wboHBFdg",
+    "Token": "",
     "PublicBaseUrl": "https://api-opto.vestor.uz",
     "MiniAppUrl": "https://opto.vestor.uz",
     "WebhookSecretToken": "MySecret",

--- a/src/VendlyServer.Api/appsettings.Staging.json
+++ b/src/VendlyServer.Api/appsettings.Staging.json
@@ -17,15 +17,15 @@
     ]
   },
   "ConnectionStrings": {
-    "DefaultConnectionString": "Host=host.docker.internal;Port=5432;Database=stage_vendly_db;Username=postgres;Password=K@3wF!8zQ2#eRt"
+    "DefaultConnectionString": "Host=host.docker.internal;Port=5432;Database=stage_vendly_db;Username=postgres;Password="
   },
   "Client": {
     "BaseUrl": "https://stage-opto.vestor.uz"
   },
   "Hamkor": {
     "BaseUrl": "https://test-openapi.hamkorbank.uz",
-    "Key": "2w0M5cc9RRPSMcAeRNsdvKf_YFga",
-    "Secret": "UEwRqqTQhernbPR89M_PMAaUqg4a",
+    "Key": "",
+    "Secret": "",
     "CallbackBaseUrl": "https://api-stage-opto.vestor.uz",
     "Tin": "310070597",
     "Spic": "08418001001002105",
@@ -53,7 +53,7 @@
     }
   },
   "Jwt": {
-    "SecretKey": "StagingVendlySecretKeyasdqwe123dasdhtjdbnfkjasuid",
+    "SecretKey": "",
     "Issuer": "VendlyServer",
     "Audience": "VendlyClient",
     "ExpirationInMinutes": 120
@@ -61,7 +61,7 @@
   "Minio": {
     "Endpoint": "minio:9000",
     "AccessKey": "vendlyadmin",
-    "SecretKey": "rI0eSKvglRFjLz0TxhrlBB5I0boruQnf",
+    "SecretKey": "",
     "BucketName": "stage-vendly",
     "PublicBaseUrl": "https://files.vestor.uz",
     "UseSsl": false
@@ -73,7 +73,7 @@
   },
   "TelegramBot": {
     "Enabled": true,
-    "Token": "8729785259:AAGZvxgnYzhylTPervZHS51iF44wboHBFdg",
+    "Token": "",
     "PublicBaseUrl": "https://api-stage-opto.vestor.uz",
     "MiniAppUrl": "https://stage-opto.vestor.uz",
     "WebhookSecretToken": "MySecret",

--- a/src/VendlyServer.Api/appsettings.json
+++ b/src/VendlyServer.Api/appsettings.json
@@ -31,8 +31,8 @@
   "AllowedHosts": "*",
   "BtsExpress": {
     "BaseUrl": "https://apitest.bts.uz:28345",
-    "Login": "6798",
-    "Password": "PA9Ov*x?i5",
+    "Login": "",
+    "Password": "",
     "SenderName": "Your Store",
     "SenderPhone": "+998901234567",
     "SenderAddress": "Toshkent, address",
@@ -64,7 +64,7 @@
   "Smartup": {
     "BaseUrl": "https://erpbot-web.smartup.online",
     "ImageBaseUrl": "https://smartup.online",
-    "Token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwZXJzb25faWRzIjpbODQ1OTQ4XSwiY2hhdF9pZCI6OTA3NTY3OTU5LCJwYWdlIjoib3JkZXIiLCJob3N0X3VybCI6Imh0dHBzOi8vc21hcnR1cC5vbmxpbmUvIiwiaWF0IjoxNzc0Mzc2OTQ2fQ.W92TSjeX8bbpv3KTOQDfD8vcLWMRgnKsXrTtFFPzbiE",
+    "Token": "",
     "PersonId": "845948",
     "FilialId": "826189"
   }


### PR DESCRIPTION
## Summary

Fixes #212
Fixes #200
Fixes #169
Fixes #165

Multiple live credentials were committed to tracked config files. This PR replaces all hardcoded secrets with empty strings so they must be supplied at runtime via environment variables, Docker secrets, or a secrets manager.

### Credentials removed

| File | Field | Description |
|------|-------|-------------|
| `appsettings.json` | `Smartup:Token` | Live Smartup ERP JWT token |
| `appsettings.json` | `BtsExpress:Login` / `Password` | BtsExpress API credentials |
| `appsettings.Development.json` | `Jwt:SecretKey` | Dev JWT signing key |
| `appsettings.Development.json` | `Minio:SecretKey` | Minio storage secret |
| `appsettings.Development.json` | `TelegramBot:Token` | Telegram Bot API token |
| `appsettings.Development.json` | `Hamkor:Key` / `Secret` | Hamkor Bank API credentials |
| `appsettings.Staging.json` | `Jwt:SecretKey` | Staging JWT signing key |
| `appsettings.Staging.json` | `Minio:SecretKey` | Minio storage secret (shared) |
| `appsettings.Staging.json` | `TelegramBot:Token` | Telegram Bot API token (shared) |
| `appsettings.Staging.json` | `Hamkor:Key` / `Secret` | Hamkor Bank API credentials |
| `appsettings.Staging.json` | `ConnectionStrings:DefaultConnectionString` | PostgreSQL password |
| `appsettings.Production.json` | `Jwt:SecretKey` | Production JWT signing key |
| `appsettings.Production.json` | `Minio:SecretKey` | Minio storage secret (shared) |
| `appsettings.Production.json` | `TelegramBot:Token` | Telegram Bot API token (shared) |
| `appsettings.Production.json` | `Hamkor:Key` / `Secret` | Hamkor Bank API credentials |
| `appsettings.Production.json` | `ConnectionStrings:DefaultConnectionString` | PostgreSQL password |

### How to supply secrets at runtime

ASP.NET Core maps environment variables with `__` separators to config keys automatically:

```bash
Smartup__Token=eyJ...
Jwt__SecretKey=your-production-secret
TelegramBot__Token=123456:ABC...
Minio__SecretKey=your-minio-secret
```

For Docker/Compose, use `env_file` or Docker secrets mounted as environment variables.

---

## ⚠️ Required human action — git history still contains live credentials

This PR removes the secrets from the current HEAD. However, all credentials remain accessible in the git history. **You must take the following steps immediately:**

1. **Rotate all credentials** — generate new tokens/passwords for every secret listed above. Treat all current values as permanently compromised.
2. **Purge the history** using `git filter-repo` or BFG Repo Cleaner, then force-push all branches.
3. **Coordinate with all contributors** — after history rewrite, everyone must re-clone the repository.
4. If the repository is or was ever public (or accessible to untrusted parties), assume all listed credentials have been extracted.

## Files changed

- `src/VendlyServer.Api/appsettings.json`
- `src/VendlyServer.Api/appsettings.Development.json`
- `src/VendlyServer.Api/appsettings.Staging.json`
- `src/VendlyServer.Api/appsettings.Production.json`

## Verification

No build is required — these are JSON config file changes only. The application will fail to start if required secrets are not supplied via environment variables, which is the intended behavior (fail-fast on missing config rather than running with blank credentials).

## Risks / Assumptions

- After this PR is merged, the application **will not start** without real secrets being injected via environment variables or another external config source. Ensure deployment pipelines are updated before merging to Staging/Production.
- The DB password in `appsettings.Development.json` (`Password=root`) was not changed as it is the standard local Postgres default and not a production credential.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CK2H1NXrhtQ7LZAzsqaAjF)_