### PR TITLE
Fix #216: Add ProductFilterRequestValidator to cap PageSize on public endpoint

### DIFF
--- a/src/VendlyServer.Application/Services/Products/Contracts/ProductFilterRequestValidator.cs
+++ b/src/VendlyServer.Application/Services/Products/Contracts/ProductFilterRequestValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace VendlyServer.Application.Services.Products.Contracts;
+
+public class ProductFilterRequestValidator : AbstractValidator<ProductFilterRequest>
+{
+    public ProductFilterRequestValidator()
+    {
+        RuleFor(x => x.Page).GreaterThan(0);
+        RuleFor(x => x.PageSize).GreaterThan(0).LessThanOrEqualTo(100);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #216

The public `GET /api/products` endpoint (`[AllowAnonymous]`) accepted an unbounded `PageSize` parameter with no FluentValidation validator. Any unauthenticated caller could send `?pageSize=2147483647`, triggering a full table scan with eager-loaded `Category` and `Variants` navigations, doubling the cost via a `CountAsync` + paged fetch pattern.

**Fix:** Added `ProductFilterRequestValidator` following the project's existing validator pattern. The `ModelValidationFilter` already registered in the pipeline will automatically return 400 for out-of-range values.

## Files Changed

- `src/VendlyServer.Application/Services/Products/Contracts/ProductFilterRequestValidator.cs` *(new)*

## Verification

`dotnet` is not available in this CI container. The validator follows the identical pattern of `CreateProductRequestValidator` and `UpdateProductRequestValidator` already in the codebase. Build and test should be confirmed in CI.

## Risks / Assumptions

- PageSize cap set to 100 (same recommendation from the issue). Adjust if the business requires a different maximum.
- Existing callers passing `pageSize > 100` will receive HTTP 400 after this change — a breaking change for any client relying on large page sizes. This is intentional and consistent with the security fix.
- `Page` is validated with `GreaterThan(0)` to reject zero or negative page values.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TiMexFxu4L4Y48ivXKcFPt)_