### PR TITLE
Fix #212: Remove hardcoded Smartup API token from appsettings.json

### DIFF
--- a/src/VendlyServer.Api/appsettings.json
+++ b/src/VendlyServer.Api/appsettings.json
@@ -64,7 +64,7 @@
   "Smartup": {
     "BaseUrl": "https://erpbot-web.smartup.online",
     "ImageBaseUrl": "https://smartup.online",
-    "Token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwZXJzb25faWRzIjpbODQ1OTQ4XSwiY2hhdF9pZCI6OTA3NTY3OTU5LCJwYWdlIjoib3JkZXIiLCJob3N0X3VybCI6Imh0dHBzOi8vc21hcnR1cC5vbmxpbmUvIiwiaWF0IjoxNzc0Mzc2OTQ2fQ.W92TSjeX8bbpv3KTOQDfD8vcLWMRgnKsXrTtFFPzbiE",
+    "Token": "",
     "PersonId": "845948",
     "FilialId": "826189"
   }


### PR DESCRIPTION
## Summary

Fixes #212

A live Smartup ERP JWT (`eyJhbGci...`) was committed to the base `appsettings.json`, meaning anyone with repository read access could authenticate directly to the Smartup ERP API (`https://erpbot-web.smartup.online`) as the person in `person_ids: [845948]` — bypassing all application-level access controls.

**Fix:** The `Smartup:Token` value is replaced with an empty string. ASP.NET Core's configuration system supports overriding it at runtime via the `Smartup__Token` environment variable (double-underscore maps to the config hierarchy separator), so the application continues to work in staging/production without any code changes — only the deployment environment needs the variable set.

## Files Changed

- `src/VendlyServer.Api/appsettings.json` — `Smartup:Token` cleared to `""`

## Verification

This is a config file edit only. No code logic was changed. The build is unaffected.

## ⚠️ Required Manual Action (Not in Scope of This PR)

This PR stops the token from appearing in the **current** codebase, but the token is **still in git history** (committed in `bc68a63`). Additional steps required:

1. **Revoke the token immediately** via the Smartup admin panel. Treat it as permanently compromised.
2. **Purge git history** with `git filter-repo --path src/VendlyServer.Api/appsettings.json --invert-paths` or BFG Repo Cleaner targeting the token value.
3. **Force-push** after rewriting history. All contributors must re-clone.
4. **Verify** `appsettings.Development.json` and `appsettings.Staging.json` do not also contain the token.
5. **Set** `Smartup__Token` in the deployment environment (Docker secrets, Kubernetes secret, Azure Key Vault, etc.).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TiMexFxu4L4Y48ivXKcFPt)_