### PR TITLE
Fix #220: Restrict AdminController to Admin,Manager roles

### DIFF
--- a/src/VendlyServer.Api/Controllers/Common/AdminController.cs
+++ b/src/VendlyServer.Api/Controllers/Common/AdminController.cs
@@ -1,5 +1,8 @@
+using Microsoft.AspNetCore.Authorization;
+
 namespace VendlyServer.Api.Controllers.Common;
 
+[Authorize(Roles = "Admin,Manager")]
 public abstract class AdminController : AuthorizedController
 {
 }


### PR DESCRIPTION
## Summary

Fixes #220

`AdminController` inherited from `AuthorizedController` which only required `[Authorize]` (any valid JWT). This meant `SyncLogsController` — which provides access to internal Smartup sync logs and a Hangfire job trigger — was reachable by any authenticated user, including `Customer`-role tokens.

Added `[Authorize(Roles = "Admin,Manager")]` to `AdminController` so all current and future controllers inheriting from it are protected by default, consistent with the role-based pattern already used throughout the codebase (e.g. `UsersController`).

## Files Changed

- `src/VendlyServer.Api/Controllers/Common/AdminController.cs` — added `[Authorize(Roles = "Admin,Manager")]`

## Verification

`dotnet` is not available in the automated execution environment, so a local build could not be run. The change is a single attribute addition with no new dependencies; no compilation errors are expected. Please run `dotnet build` and `dotnet test` before merging.

## Risks / Assumptions

- Only `SyncLogsController` currently inherits from `AdminController`. `UsersController` inherits directly from `AuthorizedController` and applies its own per-endpoint role guards — it is unaffected.
- If any future controller that extends `AdminController` legitimately needs to serve non-admin roles, it should override with its own `[Authorize]` attribute or inherit from `AuthorizedController` directly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8VeqbQNP2SEzyqjeWFn5b)_