### PR TITLE
Fix #221: Remove Hangfire dashboard default password from appsettings

### DIFF
--- a/src/VendlyServer.Api/Program.cs
+++ b/src/VendlyServer.Api/Program.cs
@@ -61,6 +61,11 @@ var hangfireUser = app.Configuration["Hangfire:Dashboard:Username"]
 var hangfirePwd = app.Configuration["Hangfire:Dashboard:Password"]
     ?? throw new InvalidOperationException("Hangfire:Dashboard:Password is not configured.");
 
+if (string.IsNullOrWhiteSpace(hangfireUser))
+    throw new InvalidOperationException("Hangfire:Dashboard:Username must not be empty. Set it via the Hangfire__Dashboard__Username environment variable.");
+if (string.IsNullOrWhiteSpace(hangfirePwd))
+    throw new InvalidOperationException("Hangfire:Dashboard:Password must not be empty. Set it via the Hangfire__Dashboard__Password environment variable.");
+
 app.UseHangfireDashboard("/hangfire", new DashboardOptions
 {
     Authorization = new[] { new HangfireAuthorizationFilter(hangfireUser, hangfirePwd) }

--- a/src/VendlyServer.Api/appsettings.json
+++ b/src/VendlyServer.Api/appsettings.json
@@ -52,8 +52,8 @@
   },
   "Hangfire": {
     "Dashboard": {
-      "Username": "admin",
-      "Password": "changeme"
+      "Username": "",
+      "Password": ""
     }
   },
   "Analytics": {


### PR DESCRIPTION
## Summary

Fixes #221

The base `appsettings.json` contained `"Password": "changeme"` for the Hangfire dashboard — a trivially guessable credential protecting an endpoint that exposes background job state and lets any user manually enqueue catalog sync jobs. Environments that failed to override the value were silently exposed.

**Changes:**
1. Cleared `Hangfire:Dashboard:Username` and `Hangfire:Dashboard:Password` to empty strings in `appsettings.json`, making the "must be supplied externally" intent explicit.
2. Added startup guards in `Program.cs` that throw `InvalidOperationException` on empty/whitespace values, so a deployment that omits the env vars fails fast at startup instead of running with no credentials.

Values should be supplied at runtime via environment variables:
```
Hangfire__Dashboard__Username=admin
Hangfire__Dashboard__Password=<strong-password>
```

## Files Changed

- `src/VendlyServer.Api/appsettings.json` — cleared username/password to `""`
- `src/VendlyServer.Api/Program.cs` — added non-empty startup guards

## Verification

`dotnet` is not available in the automated execution environment. The change is additive (adds guard checks). Build and test should be confirmed in CI. Note: after this change, any environment that does not set `Hangfire__Dashboard__Username` and `Hangfire__Dashboard__Password` will fail to start — this is intentional.

## Risks / Assumptions

- **Breaking for unconfigured environments**: any deployment that relied on the `changeme` default will fail to start after this change. Update deployment configs / secrets before merging.
- The Smartup token in `appsettings.json` (a separate security issue tracked in #212) is left unchanged in this PR to keep the fixes focused.
- Network-level restriction on `/hangfire` (reverse-proxy IP allowlist) remains a recommended defense-in-depth measure but is out of scope for this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8VeqbQNP2SEzyqjeWFn5b)_