### PR TITLE
Fix #84: Enforce email uniqueness in RegisterAsync

### DIFF
--- a/src/VendlyServer.Application/Services/Auth/AuthService.cs
+++ b/src/VendlyServer.Application/Services/Auth/AuthService.cs
@@ -35,7 +35,7 @@ public class AuthService(
     {
         var exists = await dbContext.Users
             .AsNoTracking()
-            .AnyAsync(u => u.Phone == request.Phone && !u.IsDeleted, cancellationToken);
+            .AnyAsync(u => (u.Phone == request.Phone || (request.Email != null && u.Email == request.Email)) && !u.IsDeleted, cancellationToken);
 
         if (exists) return AuthErrors.UserAlreadyExists;
 


### PR DESCRIPTION
## Summary

Fixes #84

`RegisterAsync` checked only phone uniqueness before inserting a new user. Two users could register with the same email address on different phone numbers. Once that happened, any email-based login attempt triggered `InvalidOperationException` from `SingleOrDefaultAsync` (sequence contains more than one element), producing an unhandled HTTP 500 — permanently breaking email login for both accounts.

**Fix:** Extended the existence check to cover both phone and email in a single query, avoiding an extra DB round-trip. The email guard only applies when `request.Email` is non-null (email is optional in `RegisterRequest`).

```csharp
// Before
.AnyAsync(u => u.Phone == request.Phone && !u.IsDeleted, ...)

// After
.AnyAsync(u => (u.Phone == request.Phone || (request.Email != null && u.Email == request.Email)) && !u.IsDeleted, ...)
```

Both cases return `AuthErrors.UserAlreadyExists` (HTTP 409), which is the correct contract for duplicate registration.

## Files Changed

- `src/VendlyServer.Application/Services/Auth/AuthService.cs` — combined uniqueness check in `RegisterAsync`

## Verification

`dotnet` is not available in the automated execution environment. Build and test should be confirmed in CI.

## Risks / Assumptions

- A DB-level unique constraint on `Email` would provide stronger protection against concurrent duplicate inserts (race condition). This fix handles the common-case sequential path; adding a unique index on `Users.Email` is recommended as a follow-up for full protection.
- Existing duplicate emails in the database (if any were created before this fix) are not cleaned up by this change — those rows still need manual remediation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8VeqbQNP2SEzyqjeWFn5b)_