### PR TITLE
Fix #105: Replace .First() with .Single() in BulkUpdateVariantsAsync

### DIFF
--- a/src/VendlyServer.Application/Services/Products/ProductService.cs
+++ b/src/VendlyServer.Application/Services/Products/ProductService.cs
@@ -443,7 +443,7 @@ public class ProductService(
 
         foreach (var item in request.Variants)
         {
-            var variant = variants.First(v => v.Id == item.Id);
+            var variant = variants.Single(v => v.Id == item.Id);
             variant.Name = item.Name;
             variant.Price = item.Price;
             variant.Quantity = item.Quantity;


### PR DESCRIPTION
## Summary

Fixes #105 (Warning 2 — `.First()` used on in-memory collection in `BulkUpdateVariantsAsync`)

The project coding standard (`best-practices.md`) explicitly prohibits `.First()`. In `ProductService.BulkUpdateVariantsAsync`, `variants.First(v => v.Id == item.Id)` was used to match each requested variant ID against the loaded list.

**Fix:** Changed to `.Single(v => v.Id == item.Id)`. The method already validates `variants.Count == requestedIds.Count` before the loop, so exactly one match per ID is guaranteed. `.Single()` enforces that invariant and throws a clearer exception than `.First()` if the assumption is ever violated.

Note: Warning 1 from issue #105 (the `ToLower()` index issue in `SearchAsync`) requires adding PostgreSQL functional/trigram indexes — out of scope for this focused fix.

## Files Changed

- `src/VendlyServer.Application/Services/Products/ProductService.cs` — `BulkUpdateVariantsAsync`, line 446

## Verification

`dotnet` is not available in the automated execution environment. The change is a one-line swap with no behavioral difference under valid inputs. Build and test should be confirmed in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8VeqbQNP2SEzyqjeWFn5b)_