### PR TITLE
feat(bts): delivery cost calc, branch selection, sync & order hardening

### DIFF
--- a/src/VendlyServer.Api/Controllers/Orders/OrdersController.cs
+++ b/src/VendlyServer.Api/Controllers/Orders/OrdersController.cs
@@ -32,6 +32,17 @@ public class OrdersController(IOrderService orderService, ICheckoutService check
     }
 
     /// <summary>Initiate payment for a draft order with the chosen provider (Hamkor/Payme/Click) and return the payment page URL.</summary>
+    /// <summary>Calculate the BTS delivery cost for the current cart and a chosen address (checkout preview).</summary>
+    [HttpGet("shipping-quote")]
+    public async Task<IResult> GetShippingQuoteAsync(
+        [FromQuery] long addressId,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await orderService.QuoteForAddressAsync(UserId, addressId, cancellationToken);
+        return result.IsSuccess ? Results.Ok(result.Data) : result.ToProblemDetails();
+    }
+
+    /// <summary>Initiate payment for a draft order and return the Hamkorbank payment page URL.</summary>
     [HttpPost("{id:long}/payment")]
     public async Task<IResult> InitiatePaymentAsync(
         long id,

--- a/src/VendlyServer.Api/Controllers/Orders/ShippingController.cs
+++ b/src/VendlyServer.Api/Controllers/Orders/ShippingController.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Mvc;
+using VendlyServer.Api.Controllers.Common;
+using VendlyServer.Application.Services.Shipping;
+using VendlyServer.Application.Services.Shipping.Contracts;
+
+namespace VendlyServer.Api.Controllers.Orders;
+
+[Route("api/shipping")]
+public class ShippingController(IShippingCalculatorService shippingCalculatorService) : AuthorizedController
+{
+    /// <summary>Calculate the BTS delivery cost for a receiver city and parcel weight.</summary>
+    [HttpPost("quote")]
+    public async Task<IResult> QuoteAsync(
+        [FromBody] ShippingQuoteRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await shippingCalculatorService.CalculateAsync(request, cancellationToken);
+        return result.IsSuccess ? Results.Ok(result.Data) : result.ToProblemDetails();
+    }
+}

--- a/src/VendlyServer.Api/Controllers/Ref/BtsBranchesController.cs
+++ b/src/VendlyServer.Api/Controllers/Ref/BtsBranchesController.cs
@@ -9,12 +9,20 @@ namespace VendlyServer.Api.Controllers.Ref;
 [Route("api/bts/branches")]
 public class BtsBranchesController(IBtsRefService btsRefService) : AuthorizedController
 {
-    /// <summary>Get all BTS branches.</summary>
+    /// <summary>Get BTS branches. Optionally filter by region code or city code.</summary>
     [AllowAnonymous]
     [HttpGet]
-    public async Task<IResult> GetAllAsync(CancellationToken cancellationToken = default)
+    public async Task<IResult> GetAllAsync(
+        [FromQuery] string? regionCode = null,
+        [FromQuery] string? cityCode = null,
+        CancellationToken cancellationToken = default)
     {
-        var result = await btsRefService.GetAllBranchesAsync(cancellationToken);
+        var result = !string.IsNullOrWhiteSpace(regionCode)
+            ? await btsRefService.GetBranchesByRegionAsync(regionCode, cancellationToken)
+            : !string.IsNullOrWhiteSpace(cityCode)
+                ? await btsRefService.GetBranchesByCityAsync(cityCode, cancellationToken)
+                : await btsRefService.GetAllBranchesAsync(cancellationToken);
+
         return result.IsSuccess ? Results.Ok(result.Data) : result.ToProblemDetails();
     }
 

--- a/src/VendlyServer.Api/appsettings.json
+++ b/src/VendlyServer.Api/appsettings.json
@@ -32,12 +32,15 @@
   "BtsExpress": {
     "BaseUrl": "https://apitest.bts.uz:28345",
     "Login": "6798",
-    "Password": "PA9Ov*x?i5",
-    "SenderName": "Your Store",
-    "SenderPhone": "+998901234567",
+    "Password": "PA9Qv*x?i5",
+    "SenderName": "Opto Store",
+    "SenderPhone": "+998938725775",
+    "DefaultPickupType": "branch",
     "SenderAddress": "Toshkent, address",
-    "SenderCityCode": "0101",
-    "SenderBranchCode": "0101"
+    "SenderCityCode": "0109",
+    "SenderBranchCode": "0154",
+    "DefaultPackageId": 7,
+    "DefaultPostTypeId": 7
   },
   "CurrencyApi": {
     "BaseUrl": "https://api.freecurrencyapi.com/v1/",

--- a/src/VendlyServer.Application/Dependencies.cs
+++ b/src/VendlyServer.Application/Dependencies.cs
@@ -58,6 +58,7 @@ public static class Dependencies
         services.AddScoped<ICheckoutService, CheckoutService>();
         services.AddScoped<IOrderService, OrderService>();
         services.AddScoped<IOrderShippingService, OrderShippingService>();
+        services.AddScoped<IShippingCalculatorService, ShippingCalculatorService>();
         services.AddScoped<ICurrencyConverterService, CurrencyConverterService>();
         services.AddScoped<IAnalyticsService, AnalyticsService>();
         services.AddScoped<ISyncLogService, SyncLogService>();

--- a/src/VendlyServer.Application/Jobs/BtsCatalog/BtsCatalogSyncJob.cs
+++ b/src/VendlyServer.Application/Jobs/BtsCatalog/BtsCatalogSyncJob.cs
@@ -80,6 +80,9 @@ public class BtsCatalogSyncJob(
         return regions;
     }
 
+    // BTS rate-limit (429) ga tushmaslik uchun ketma-ket so'rovlar orasidagi kechikish.
+    private const int ThrottleDelayMs = 400;
+
     private async Task SyncCitiesAndBranchesAsync(List<BtsRegion> regions, DateTime syncedAt,
         CancellationToken cancellationToken)
     {
@@ -96,6 +99,7 @@ public class BtsCatalogSyncJob(
 
         foreach (var region in regions)
         {
+            await Task.Delay(ThrottleDelayMs, cancellationToken);
             var citiesResult = await btsBroker.GetCitiesAsync(region.Code, forceRefresh: true, cancellationToken);
             if (citiesResult.IsFailure)
             {
@@ -107,6 +111,10 @@ public class BtsCatalogSyncJob(
             var cities = citiesResult.Data!;
             foreach (var city in cities)
             {
+                // Bo'sh kodli yozuvlar unique indeksda to'qnashadi — o'tkazib yuboramiz.
+                if (string.IsNullOrWhiteSpace(city.Code))
+                    continue;
+
                 if (existingCities.TryGetValue(city.Code, out var cityEntity))
                 {
                     cityEntity.RegionCode = region.Code;
@@ -116,16 +124,21 @@ public class BtsCatalogSyncJob(
                 }
                 else
                 {
-                    dbContext.BtsCities.Add(new BtsCityRef
+                    var newCity = new BtsCityRef
                     {
                         RegionCode = region.Code,
                         Code = city.Code,
                         Name = city.Name,
                         SyncedAt = syncedAt
-                    });
+                    };
+                    dbContext.BtsCities.Add(newCity);
+                    // Yangi entity'ni lug'atga qo'shamiz — aks holda shu run'da kod
+                    // takrorlansa qayta INSERT bo'lib, unique indeks buziladi.
+                    existingCities[city.Code] = newCity;
                     citiesCreated++;
                 }
 
+                await Task.Delay(ThrottleDelayMs, cancellationToken);
                 var branchesResult = await btsBroker.GetBranchesAsync(
                     region.Code, city.Code, forceRefresh: true, cancellationToken);
 
@@ -139,6 +152,10 @@ public class BtsCatalogSyncJob(
 
                 foreach (var branch in branchesResult.Data!)
                 {
+                    // Bo'sh kodli yozuvlar unique indeksda to'qnashadi — o'tkazib yuboramiz.
+                    if (string.IsNullOrWhiteSpace(branch.Code))
+                        continue;
+
                     if (existingBranches.TryGetValue(branch.Code, out var branchEntity))
                     {
                         branchEntity.RegionCode = branch.RegionCode;
@@ -153,7 +170,7 @@ public class BtsCatalogSyncJob(
                     }
                     else
                     {
-                        dbContext.BtsBranches.Add(new BtsBranchRef
+                        var newBranch = new BtsBranchRef
                         {
                             RegionCode = branch.RegionCode,
                             CityCode = branch.CityCode,
@@ -164,7 +181,11 @@ public class BtsCatalogSyncJob(
                             LatLong = branch.LatLong,
                             WorkingHours = SerializeWorkingHours(branch.WorkingHours),
                             SyncedAt = syncedAt
-                        });
+                        };
+                        dbContext.BtsBranches.Add(newBranch);
+                        // Yangi entity'ni lug'atga qo'shamiz — shu run'da kod takrorlansa
+                        // qayta INSERT bo'lib unique indeks buzilishining oldini oladi.
+                        existingBranches[branch.Code] = newBranch;
                         branchesCreated++;
                     }
                 }

--- a/src/VendlyServer.Application/Jobs/JobsRegistrar.cs
+++ b/src/VendlyServer.Application/Jobs/JobsRegistrar.cs
@@ -10,10 +10,10 @@ public static class JobsRegistrar
     public static void RegisterRecurringJobs()
     {
         // BTS catalog sync — runs every Sunday at 03:00 UTC
-        // RecurringJob.AddOrUpdate<IBtsCatalogSyncJob>(
-        //     "bts-catalog-sync",
-        //     job => job.ExecuteAsync(CancellationToken.None),
-        //     Cron.Weekly(DayOfWeek.Sunday, 3));
+        RecurringJob.AddOrUpdate<IBtsCatalogSyncJob>(
+            "bts-catalog-sync",
+            job => job.ExecuteAsync(CancellationToken.None),
+            Cron.Weekly(DayOfWeek.Sunday, 3));
 
         RecurringJob.AddOrUpdate<ICleanExpiredRefreshTokensJob>(
             "clean-expired-refresh-tokens",

--- a/src/VendlyServer.Application/Services/Addresses/AddressErrors.cs
+++ b/src/VendlyServer.Application/Services/Addresses/AddressErrors.cs
@@ -10,4 +10,7 @@ public static class AddressErrors
 
     public static readonly Error BtsCityCodeInvalid =
         Error.Validation("Address.BtsCityCodeInvalid", "BtsCityCode does not exist.");
+
+    public static readonly Error BtsBranchCodeInvalid =
+        Error.Validation("Address.BtsBranchCodeInvalid", "BtsBranchCode does not exist in the selected city.");
 }

--- a/src/VendlyServer.Application/Services/Addresses/AddressService.cs
+++ b/src/VendlyServer.Application/Services/Addresses/AddressService.cs
@@ -26,6 +26,7 @@ public class AddressService(AppDbContext dbContext) : IAddressService
                 a.House,
                 a.Extra,
                 a.BtsCityCode,
+                a.BtsBranchCode,
                 a.IsDefault,
                 a.CreatedAt))
             .ToListAsync(cancellationToken);
@@ -47,6 +48,7 @@ public class AddressService(AppDbContext dbContext) : IAddressService
                 a.House,
                 a.Extra,
                 a.BtsCityCode,
+                a.BtsBranchCode,
                 a.IsDefault,
                 a.CreatedAt))
             .SingleOrDefaultAsync(cancellationToken);
@@ -62,6 +64,9 @@ public class AddressService(AppDbContext dbContext) : IAddressService
 
         if (!btsCityExists)
             return AddressErrors.BtsCityCodeInvalid;
+
+        if (!await BtsBranchIsValidAsync(request.BtsBranchCode, request.BtsCityCode, cancellationToken))
+            return AddressErrors.BtsBranchCodeInvalid;
 
         var existingCount = await dbContext.Addresses
             .AsNoTracking()
@@ -92,6 +97,7 @@ public class AddressService(AppDbContext dbContext) : IAddressService
             House = request.House,
             Extra = request.Extra,
             BtsCityCode = request.BtsCityCode,
+            BtsBranchCode = request.BtsBranchCode,
             IsDefault = shouldBeDefault
         };
 
@@ -107,6 +113,7 @@ public class AddressService(AppDbContext dbContext) : IAddressService
             address.House,
             address.Extra,
             address.BtsCityCode,
+            address.BtsBranchCode,
             address.IsDefault,
             address.CreatedAt);
     }
@@ -129,6 +136,9 @@ public class AddressService(AppDbContext dbContext) : IAddressService
                 return AddressErrors.BtsCityCodeInvalid;
         }
 
+        if (!await BtsBranchIsValidAsync(request.BtsBranchCode, request.BtsCityCode, cancellationToken))
+            return AddressErrors.BtsBranchCodeInvalid;
+
         if (request.IsDefault && !address.IsDefault)
         {
             var defaults = await dbContext.Addresses
@@ -146,6 +156,7 @@ public class AddressService(AppDbContext dbContext) : IAddressService
         address.House = request.House;
         address.Extra = request.Extra;
         address.BtsCityCode = request.BtsCityCode;
+        address.BtsBranchCode = request.BtsBranchCode;
         address.IsDefault = request.IsDefault || address.IsDefault;
 
         await dbContext.SaveChangesAsync(cancellationToken);
@@ -159,6 +170,7 @@ public class AddressService(AppDbContext dbContext) : IAddressService
             address.House,
             address.Extra,
             address.BtsCityCode,
+            address.BtsBranchCode,
             address.IsDefault,
             address.CreatedAt);
     }
@@ -220,7 +232,29 @@ public class AddressService(AppDbContext dbContext) : IAddressService
             address.House,
             address.Extra,
             address.BtsCityCode,
+            address.BtsBranchCode,
             address.IsDefault,
             address.CreatedAt);
+    }
+
+    // Branch is optional; when provided it must belong to the same region as the
+    // selected city (branches across the whole region are offered to the user).
+    private async Task<bool> BtsBranchIsValidAsync(string? branchCode, string cityCode, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(branchCode))
+            return true;
+
+        var regionCode = await dbContext.BtsCities
+            .AsNoTracking()
+            .Where(c => c.Code == cityCode)
+            .Select(c => c.RegionCode)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (regionCode is null)
+            return false;
+
+        return await dbContext.BtsBranches
+            .AsNoTracking()
+            .AnyAsync(b => b.Code == branchCode && b.RegionCode == regionCode, cancellationToken);
     }
 }

--- a/src/VendlyServer.Application/Services/Addresses/Contracts/AddressResponse.cs
+++ b/src/VendlyServer.Application/Services/Addresses/Contracts/AddressResponse.cs
@@ -9,6 +9,7 @@ public record AddressResponse(
     string House,
     string? Extra,
     string BtsCityCode,
+    string? BtsBranchCode,
     bool IsDefault,
     DateTime CreatedAt
 );

--- a/src/VendlyServer.Application/Services/Addresses/Contracts/CreateAddressRequest.cs
+++ b/src/VendlyServer.Application/Services/Addresses/Contracts/CreateAddressRequest.cs
@@ -8,5 +8,6 @@ public record CreateAddressRequest(
     string House,
     string? Extra,
     string BtsCityCode,
+    string? BtsBranchCode,
     bool IsDefault
 );

--- a/src/VendlyServer.Application/Services/Addresses/Contracts/CreateAddressRequestValidator.cs
+++ b/src/VendlyServer.Application/Services/Addresses/Contracts/CreateAddressRequestValidator.cs
@@ -32,5 +32,8 @@ public class CreateAddressRequestValidator : AbstractValidator<CreateAddressRequ
         RuleFor(x => x.BtsCityCode)
             .NotEmpty().WithMessage("BtsCityCode is required.")
             .MaximumLength(10).WithMessage("BtsCityCode must not exceed 10 characters.");
+
+        RuleFor(x => x.BtsBranchCode)
+            .MaximumLength(10).WithMessage("BtsBranchCode must not exceed 10 characters.");
     }
 }

--- a/src/VendlyServer.Application/Services/Addresses/Contracts/UpdateAddressRequest.cs
+++ b/src/VendlyServer.Application/Services/Addresses/Contracts/UpdateAddressRequest.cs
@@ -8,5 +8,6 @@ public record UpdateAddressRequest(
     string House,
     string? Extra,
     string BtsCityCode,
+    string? BtsBranchCode,
     bool IsDefault
 );

--- a/src/VendlyServer.Application/Services/Addresses/Contracts/UpdateAddressRequestValidator.cs
+++ b/src/VendlyServer.Application/Services/Addresses/Contracts/UpdateAddressRequestValidator.cs
@@ -32,5 +32,8 @@ public class UpdateAddressRequestValidator : AbstractValidator<UpdateAddressRequ
         RuleFor(x => x.BtsCityCode)
             .NotEmpty().WithMessage("BtsCityCode is required.")
             .MaximumLength(10).WithMessage("BtsCityCode must not exceed 10 characters.");
+
+        RuleFor(x => x.BtsBranchCode)
+            .MaximumLength(10).WithMessage("BtsBranchCode must not exceed 10 characters.");
     }
 }

--- a/src/VendlyServer.Application/Services/BtsRef/BtsRefService.cs
+++ b/src/VendlyServer.Application/Services/BtsRef/BtsRefService.cs
@@ -161,6 +161,34 @@ public class BtsRefService(AppDbContext dbContext) : IBtsRefService
             .ToListAsync(cancellationToken);
     }
 
+    public async Task<Result<List<BtsBranchResponse>>> GetBranchesByCityAsync(string cityCode, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.BtsBranches
+            .AsNoTracking()
+            .Where(b => b.CityCode == cityCode)
+            .Select(b => new BtsBranchResponse
+            {
+                Id = b.Id, RegionCode = b.RegionCode, CityCode = b.CityCode,
+                Code = b.Code, Name = b.Name, Address = b.Address,
+                Phone = b.Phone, LatLong = b.LatLong, WorkingHours = b.WorkingHours, SyncedAt = b.SyncedAt
+            })
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<Result<List<BtsBranchResponse>>> GetBranchesByRegionAsync(string regionCode, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.BtsBranches
+            .AsNoTracking()
+            .Where(b => b.RegionCode == regionCode)
+            .Select(b => new BtsBranchResponse
+            {
+                Id = b.Id, RegionCode = b.RegionCode, CityCode = b.CityCode,
+                Code = b.Code, Name = b.Name, Address = b.Address,
+                Phone = b.Phone, LatLong = b.LatLong, WorkingHours = b.WorkingHours, SyncedAt = b.SyncedAt
+            })
+            .ToListAsync(cancellationToken);
+    }
+
     public async Task<Result<BtsBranchResponse>> GetBranchByIdAsync(long id, CancellationToken cancellationToken = default)
     {
         var branch = await dbContext.BtsBranches

--- a/src/VendlyServer.Application/Services/BtsRef/IBtsRefService.cs
+++ b/src/VendlyServer.Application/Services/BtsRef/IBtsRefService.cs
@@ -21,6 +21,8 @@ public interface IBtsRefService
 
     // Branches
     Task<Result<List<BtsBranchResponse>>> GetAllBranchesAsync(CancellationToken cancellationToken = default);
+    Task<Result<List<BtsBranchResponse>>> GetBranchesByCityAsync(string cityCode, CancellationToken cancellationToken = default);
+    Task<Result<List<BtsBranchResponse>>> GetBranchesByRegionAsync(string regionCode, CancellationToken cancellationToken = default);
     Task<Result<BtsBranchResponse>> GetBranchByIdAsync(long id, CancellationToken cancellationToken = default);
     Task<Result> AddBranchAsync(SaveBtsBranchRequest request, CancellationToken cancellationToken = default);
     Task<Result> UpdateBranchAsync(long id, SaveBtsBranchRequest request, CancellationToken cancellationToken = default);

--- a/src/VendlyServer.Application/Services/Carts/CartService.cs
+++ b/src/VendlyServer.Application/Services/Carts/CartService.cs
@@ -157,7 +157,9 @@ public class CartService(
 
         if (order is not null && pricing is not null)
         {
-            OrderItemSync.Apply(order, cart.Items, pricing);
+            // Yetkazib berish narxi checkout (CreateDraft/SetAddress) da qayta hisoblanadi;
+            // bu yerda mavjud snapshotni saqlaymiz.
+            OrderItemSync.Apply(order, cart.Items, pricing, order.DeliveryCost);
             RevertToDraftIfNew(order);
             await dbContext.SaveChangesAsync(cancellationToken);
         }
@@ -171,7 +173,7 @@ public class CartService(
         var pricing = await ResolvePricingContextAsync(cancellationToken);
         if (pricing is null) return;
 
-        OrderItemSync.Apply(order, cart.Items, pricing);
+        OrderItemSync.Apply(order, cart.Items, pricing, order.DeliveryCost);
         RevertToDraftIfNew(order);
     }
 

--- a/src/VendlyServer.Application/Services/Orders/IOrderService.cs
+++ b/src/VendlyServer.Application/Services/Orders/IOrderService.cs
@@ -1,5 +1,6 @@
 using VendlyServer.Domain.Abstractions;
 using VendlyServer.Application.Services.Orders.Contracts;
+using VendlyServer.Application.Services.Shipping.Contracts;
 
 namespace VendlyServer.Application.Services.Orders;
 
@@ -8,6 +9,7 @@ public interface IOrderService
     // Customer — checkout flow
     Task<Result<CreateOrderResponse>> CreateDraftAsync(long userId, CreateOrderRequest request, CancellationToken cancellationToken = default);
     Task<Result> SetAddressAsync(long userId, long id, SetOrderAddressRequest request, CancellationToken cancellationToken = default);
+    Task<Result<ShippingQuoteResponse>> QuoteForAddressAsync(long userId, long addressId, CancellationToken cancellationToken = default);
     Task<Result<List<OrderListItemResponse>>> GetActiveOrdersAsync(long userId, CancellationToken cancellationToken = default);
     Task<Result> CancelDraftAsync(long userId, long orderId, CancellationToken cancellationToken = default);
 

--- a/src/VendlyServer.Application/Services/Orders/OrderItemSync.cs
+++ b/src/VendlyServer.Application/Services/Orders/OrderItemSync.cs
@@ -8,10 +8,7 @@ namespace VendlyServer.Application.Services.Orders;
 // Create va cart-edit (re-sync) da bir xil ishlatiladi.
 public static class OrderItemSync
 {
-    // Mirrors the frontend DELIVERY_COST constant; move to delivery calculation/config later.
-    public const decimal DeliveryCost = 10m;
-
-    public static void Apply(Order order, IEnumerable<CartItem> cartItems, PricingContext pricing)
+    public static void Apply(Order order, IEnumerable<CartItem> cartItems, PricingContext pricing, decimal deliveryCost)
     {
         foreach (var existing in order.Items.Where(i => !i.IsDeleted))
             existing.IsDeleted = true;
@@ -39,6 +36,7 @@ public static class OrderItemSync
         }
 
         order.Subtotal = subtotal;
-        order.TotalAmount = subtotal + DeliveryCost;
+        order.DeliveryCost = deliveryCost;
+        order.TotalAmount = subtotal + deliveryCost;
     }
 }

--- a/src/VendlyServer.Application/Services/Orders/OrderService.cs
+++ b/src/VendlyServer.Application/Services/Orders/OrderService.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using VendlyServer.Application.Services.Orders.Contracts;
 using VendlyServer.Application.Services.Pricing;
 using VendlyServer.Application.Services.Shipping;
+using VendlyServer.Application.Services.Shipping.Contracts;
 using VendlyServer.Domain.Abstractions;
 using VendlyServer.Domain.Entities.Orders;
 using VendlyServer.Domain.Enums;
@@ -12,6 +13,7 @@ namespace VendlyServer.Application.Services.Orders;
 public class OrderService(
     AppDbContext dbContext,
     IOrderShippingService shippingService,
+    IShippingCalculatorService shippingCalculatorService,
     IProductPricingService pricingService) : IOrderService
 {
     // ── Customer — checkout flow ──────────────────────────────────────────────
@@ -53,8 +55,11 @@ public class OrderService(
             var existingItems = existing.Cart?.Items.Where(i => !i.IsDeleted).ToList() ?? [];
             if (existingItems.Count == 0) return OrderErrors.CartEmpty;
 
+            var existingQuote = await QuoteForCartAsync(existingItems, address, cancellationToken);
+            if (!existingQuote.IsSuccess) return existingQuote.Error;
+
             ApplyAddress(existing, address);
-            OrderItemSync.Apply(existing, existingItems, pricing);
+            OrderItemSync.Apply(existing, existingItems, pricing, existingQuote.Data!.Cost);
 
             // To'lov boshlangan (New) bo'lsa — address/itemlar o'zgardi → eski Hamkor summasi eskirdi → Draft.
             if (existing.Status == OrderStatus.New)
@@ -86,13 +91,15 @@ public class OrderService(
         var items = cart?.Items.Where(i => !i.IsDeleted).ToList() ?? [];
         if (cart is null || items.Count == 0) return OrderErrors.CartEmpty;
 
+        var quote = await QuoteForCartAsync(items, address, cancellationToken);
+        if (!quote.IsSuccess) return quote.Error;
+
         var order = new Order
         {
             UserId = userId,
             OrderNumber = GenerateOrderNumber(),
             Status = OrderStatus.Draft,
             CartId = cart.Id,
-            DeliveryCost = OrderItemSync.DeliveryCost,
             DiscountAmount = 0,
             DeliveryCity = address.City,
             DeliveryDistrict = address.District,
@@ -100,9 +107,10 @@ public class OrderService(
             DeliveryHouse = address.House,
             DeliveryExtra = address.Extra,
             DeliveryBtsCityCode = address.BtsCityCode,
+            DeliveryBtsBranchCode = address.BtsBranchCode,
         };
 
-        OrderItemSync.Apply(order, items, pricing);
+        OrderItemSync.Apply(order, items, pricing, quote.Data!.Cost);
         order.StatusHistory.Add(new OrderStatusHistory { Status = OrderStatus.Draft });
 
         // Cart endi shu orderga biriktirildi → keyingi GET /api/carts yangi bo'sh savat yaratadi.
@@ -167,21 +175,67 @@ public class OrderService(
         if (address is null) return OrderErrors.AddressNotFound;
 
         var order = await dbContext.Orders
+            .Include(o => o.Items.Where(i => !i.IsDeleted))
             .Where(o => o.Id == id && o.UserId == userId && !o.IsDeleted)
             .SingleOrDefaultAsync(cancellationToken);
 
         if (order is null) return OrderErrors.NotFound;
         if (order.Status != OrderStatus.Draft) return OrderErrors.NotDraft;
 
-        order.DeliveryCity = address.City;
-        order.DeliveryDistrict = address.District;
-        order.DeliveryStreet = address.Street;
-        order.DeliveryHouse = address.House;
-        order.DeliveryExtra = address.Extra;
-        order.DeliveryBtsCityCode = address.BtsCityCode;
+        var weight = (double)order.Items.Where(i => !i.IsDeleted).Sum(i => i.WeightKgSnap * i.Qty);
+        if (order.Items.Where(i => !i.IsDeleted).Any(i => i.WeightKgSnap <= 0) || weight <= 0)
+            return ShippingErrors.WeightMissing;
+
+        var quoteResult = await shippingCalculatorService.CalculateAsync(
+            new ShippingQuoteRequest(address.BtsCityCode, address.BtsBranchCode, weight), cancellationToken);
+        if (!quoteResult.IsSuccess) return quoteResult.Error;
+
+        ApplyAddress(order, address);
+        order.DeliveryCost = quoteResult.Data!.Cost;
+        order.TotalAmount = order.Subtotal + quoteResult.Data.Cost;
 
         await dbContext.SaveChangesAsync(cancellationToken);
         return Result.Success();
+    }
+
+    // Manzil tanlanganda checkoutdan oldin real-vaqt yetkazib berish narxini ko'rsatish uchun.
+    // Og'irlik server tomonda foydalanuvchining ochiq savatidan hisoblanadi (mijozga ishonilmaydi).
+    public async Task<Result<ShippingQuoteResponse>> QuoteForAddressAsync(
+        long userId, long addressId, CancellationToken cancellationToken = default)
+    {
+        var address = await dbContext.Addresses
+            .AsNoTracking()
+            .Where(a => a.Id == addressId && a.UserId == userId && !a.IsDeleted)
+            .SingleOrDefaultAsync(cancellationToken);
+
+        if (address is null) return OrderErrors.AddressNotFound;
+
+        var cart = await dbContext.Carts
+            .Where(c => c.UserId == userId && !c.IsDeleted && !c.IsCheckedOut)
+            .Include(c => c.Items.Where(i => !i.IsDeleted))
+                .ThenInclude(i => i.ProductVariant)
+                    .ThenInclude(v => v.Measurements)
+            .OrderBy(c => c.CreatedAt)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        var items = cart?.Items.Where(i => !i.IsDeleted).ToList() ?? [];
+        if (cart is null || items.Count == 0) return OrderErrors.CartEmpty;
+
+        return await QuoteForCartAsync(items, address, cancellationToken);
+    }
+
+    // Cart itemlaridan og'irlik hisoblab BTS quote oladi. Biror item og'irligi yoki jami og'irlik <=0 → WeightMissing.
+    private async Task<Result<ShippingQuoteResponse>> QuoteForCartAsync(
+        List<CartItem> items, Domain.Entities.Ref.Address address, CancellationToken cancellationToken)
+    {
+        var active = items.Where(i => !i.IsDeleted).ToList();
+        var weight = (double)active.Sum(i => (i.ProductVariant.Measurements?.WeightKg ?? 0) * i.Qty);
+
+        if (active.Any(i => (i.ProductVariant.Measurements?.WeightKg ?? 0) <= 0) || weight <= 0)
+            return ShippingErrors.WeightMissing;
+
+        return await shippingCalculatorService.CalculateAsync(
+            new ShippingQuoteRequest(address.BtsCityCode, address.BtsBranchCode, weight), cancellationToken);
     }
 
     // ── Customer — read ───────────────────────────────────────────────────────
@@ -397,6 +451,7 @@ public class OrderService(
         order.DeliveryHouse = address.House;
         order.DeliveryExtra = address.Extra;
         order.DeliveryBtsCityCode = address.BtsCityCode;
+        order.DeliveryBtsBranchCode = address.BtsBranchCode;
     }
 
     private IQueryable<Order> QueryDetail() =>

--- a/src/VendlyServer.Application/Services/Shipping/Contracts/ShippingQuoteRequest.cs
+++ b/src/VendlyServer.Application/Services/Shipping/Contracts/ShippingQuoteRequest.cs
@@ -1,0 +1,3 @@
+namespace VendlyServer.Application.Services.Shipping.Contracts;
+
+public record ShippingQuoteRequest(string ReceiverCityCode, string? ReceiverBranchCode, double WeightKg);

--- a/src/VendlyServer.Application/Services/Shipping/Contracts/ShippingQuoteRequestValidator.cs
+++ b/src/VendlyServer.Application/Services/Shipping/Contracts/ShippingQuoteRequestValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+
+namespace VendlyServer.Application.Services.Shipping.Contracts;
+
+public class ShippingQuoteRequestValidator : AbstractValidator<ShippingQuoteRequest>
+{
+    public ShippingQuoteRequestValidator()
+    {
+        RuleFor(x => x.ReceiverCityCode)
+            .NotEmpty().WithMessage("ReceiverCityCode is required.")
+            .MaximumLength(10).WithMessage("ReceiverCityCode must not exceed 10 characters.");
+
+        RuleFor(x => x.ReceiverBranchCode)
+            .MaximumLength(10).WithMessage("ReceiverBranchCode must not exceed 10 characters.");
+
+        RuleFor(x => x.WeightKg)
+            .GreaterThan(0).WithMessage("WeightKg must be greater than zero.");
+    }
+}

--- a/src/VendlyServer.Application/Services/Shipping/Contracts/ShippingQuoteResponse.cs
+++ b/src/VendlyServer.Application/Services/Shipping/Contracts/ShippingQuoteResponse.cs
@@ -1,0 +1,3 @@
+namespace VendlyServer.Application.Services.Shipping.Contracts;
+
+public record ShippingQuoteResponse(decimal Cost, string DropoffType, string Currency);

--- a/src/VendlyServer.Application/Services/Shipping/IShippingCalculatorService.cs
+++ b/src/VendlyServer.Application/Services/Shipping/IShippingCalculatorService.cs
@@ -1,0 +1,10 @@
+using VendlyServer.Application.Services.Shipping.Contracts;
+using VendlyServer.Domain.Abstractions;
+
+namespace VendlyServer.Application.Services.Shipping;
+
+public interface IShippingCalculatorService
+{
+    Task<Result<ShippingQuoteResponse>> CalculateAsync(
+        ShippingQuoteRequest request, CancellationToken cancellationToken = default);
+}

--- a/src/VendlyServer.Application/Services/Shipping/OrderShippingService.cs
+++ b/src/VendlyServer.Application/Services/Shipping/OrderShippingService.cs
@@ -31,11 +31,14 @@ public class OrderShippingService(
         var weight = order.Items.Where(i => !i.IsDeleted).Sum(i => (double)i.WeightKgSnap * i.Qty);
         var pieces = order.Items.Where(i => !i.IsDeleted).Sum(i => i.Qty);
 
+        // Dropoff turi quote bilan mos bo'lishi shart: filial kodi bo'lsa filialga, bo'lmasa kuryer orqali.
+        var dropoffType = string.IsNullOrWhiteSpace(order.DeliveryBtsBranchCode) ? "courier" : "branch";
+
         var request = new BtsCreateOrderRequest
         {
             ClientId = order.OrderNumber,
             PickupType = _options.DefaultPickupType,
-            DropoffType = _options.DefaultDropoffType,
+            DropoffType = dropoffType,
             Sender = new BtsParty
             {
                 Name = _options.SenderName,
@@ -51,6 +54,7 @@ public class OrderShippingService(
                 Address = $"{order.DeliveryStreet}, {order.DeliveryHouse}"
                           + (string.IsNullOrWhiteSpace(order.DeliveryExtra) ? "" : $", {order.DeliveryExtra}"),
                 CityCode = order.DeliveryBtsCityCode,
+                BranchCode = order.DeliveryBtsBranchCode,
             },
             Cargo = new BtsCargo
             {
@@ -72,7 +76,8 @@ public class OrderShippingService(
         var data = createResult.Data;
         order.BtsOrderId = data.OrderId.ToString();
         order.BtsBarcode = data.Barcode;
-        order.BtsTrackingUrl = data.Tracking;
+        // BTS ba'zan bo'sh tracking qaytaradi — bo'sh stringни saqlamaymiz.
+        order.BtsTrackingUrl = string.IsNullOrWhiteSpace(data.Tracking) ? null : data.Tracking;
         order.DeliveryStatus = DeliveryStatus.Pending;
 
         // Sticker is best-effort — don't fail the shipment if it can't be fetched.

--- a/src/VendlyServer.Application/Services/Shipping/ShippingCalculatorService.cs
+++ b/src/VendlyServer.Application/Services/Shipping/ShippingCalculatorService.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.Options;
+using VendlyServer.Application.Services.Shipping.Contracts;
+using VendlyServer.Domain.Abstractions;
+using VendlyServer.Infrastructure.Brokers.BtsExpress;
+using VendlyServer.Infrastructure.Brokers.BtsExpress.Contracts.Requests;
+using VendlyServer.Infrastructure.Brokers.BtsExpress.Contracts.Responses;
+
+namespace VendlyServer.Application.Services.Shipping;
+
+public class ShippingCalculatorService(
+    IBtsBroker btsBroker,
+    IOptions<BtsExpressOptions> options) : IShippingCalculatorService
+{
+    private const string Currency = "UZS";
+    private readonly BtsExpressOptions _options = options.Value;
+
+    public async Task<Result<ShippingQuoteResponse>> CalculateAsync(
+        ShippingQuoteRequest request, CancellationToken cancellationToken = default)
+    {
+        if (request.WeightKg <= 0)
+            return ShippingErrors.WeightMissing;
+
+        // Manzilda BTS filial kodi bo'lsa filialga, bo'lmasa kuryer orqali yetkaziladi.
+        var dropoffType = string.IsNullOrWhiteSpace(request.ReceiverBranchCode) ? "courier" : "branch";
+
+        var calcRequest = new BtsCalculateRequest
+        {
+            SenderCityCode = _options.SenderCityCode,
+            ReceiverCityCode = request.ReceiverCityCode,
+            PickupType = _options.DefaultPickupType,
+            DropoffType = dropoffType,
+            IsMultipleCost = 1,
+            Weight = request.WeightKg,
+            Volume = null,
+        };
+
+        var calcResult = await btsBroker.CalculateAsync(calcRequest, cancellationToken);
+        if (calcResult.IsFailure || calcResult.Data is null)
+            return ShippingErrors.CalculateFailed;
+
+        var option = SelectOption(calcResult.Data, _options.DefaultPickupType, dropoffType);
+        if (option is null || !option.Available)
+            return ShippingErrors.RouteUnavailable;
+
+        return new ShippingQuoteResponse(option.Price, dropoffType, Currency);
+    }
+
+    private static BtsPriceOption? SelectOption(BtsCalculateData data, string pickupType, string dropoffType) =>
+        (pickupType, dropoffType) switch
+        {
+            ("branch", "courier") => data.BranchToCourier,
+            ("branch", "branch") => data.BranchToBranch,
+            ("courier", "courier") => data.CourierToCourier,
+            ("courier", "branch") => data.CourierToBranch,
+            _ => data.BranchToCourier,
+        };
+}

--- a/src/VendlyServer.Application/Services/Shipping/ShippingErrors.cs
+++ b/src/VendlyServer.Application/Services/Shipping/ShippingErrors.cs
@@ -1,0 +1,14 @@
+using VendlyServer.Domain.Abstractions;
+
+namespace VendlyServer.Application.Services.Shipping;
+
+public static class ShippingErrors
+{
+    public static readonly Error WeightMissing = Error.Validation(
+        "Shipping.WeightMissing", "One or more products are missing a weight.");
+
+    public static readonly Error RouteUnavailable = Error.Validation(
+        "Shipping.RouteUnavailable", "Delivery is not available for this route.");
+
+    public static readonly Error CalculateFailed = Error.Failure("Shipping.CalculateFailed");
+}

--- a/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
+++ b/src/VendlyServer.Application/Services/SmartupSync/SmartupSyncService.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -243,6 +244,7 @@ public class SmartupSyncService(
         var dbProducts = await dbContext.Products
             .Where(p => !p.IsDeleted && p.CategoryId == categoryId && p.SyncSource == SyncSource.External)
             .Include(p => p.Variants)
+                .ThenInclude(v => v.Measurements)
             .ToListAsync(cancellationToken);
 
         var existingDict = dbProducts
@@ -256,6 +258,10 @@ public class SmartupSyncService(
         {
             var price = decimal.TryParse(item.Price, out var p) ? p : 0m;
             var quantity = int.TryParse(item.BalanceQuant, out var q) ? q : 0;
+            // weight_brutto, kg, konvertatsiyasiz. Parse bo'lmasa/null → 0 (default og'irlik QO'YMAYMIZ).
+            var weightKg = decimal.TryParse(item.WeightBrutto, NumberStyles.Any, CultureInfo.InvariantCulture, out var w)
+                ? w
+                : 0m;
             var images = new List<string>();
             foreach (var sha in item.PhotoSha)
             {
@@ -294,6 +300,11 @@ public class SmartupSyncService(
                     variant.Quantity = quantity;
                     variant.Images = images;
                     variant.IsActive = true;
+
+                    if (variant.Measurements is null)
+                        variant.Measurements = new ProductMeasurement { WeightKg = weightKg };
+                    else
+                        variant.Measurements.WeightKg = weightKg;
                 }
 
                 updated++;
@@ -316,7 +327,8 @@ public class SmartupSyncService(
                     Price = price,
                     Quantity = quantity,
                     Images = images,
-                    IsActive = true
+                    IsActive = true,
+                    Measurements = new ProductMeasurement { WeightKg = weightKg }
                 });
 
                 created++;

--- a/src/VendlyServer.Domain/Entities/Orders/Order.cs
+++ b/src/VendlyServer.Domain/Entities/Orders/Order.cs
@@ -50,6 +50,9 @@ public class Order : AuditableModelBase<long>
     [MaxLength(10)]
     public required string DeliveryBtsCityCode { get; set; }
 
+    [MaxLength(10)]
+    public string? DeliveryBtsBranchCode { get; set; }
+
     [MaxLength(50)]
     public string? BtsOrderId { get; set; }
 

--- a/src/VendlyServer.Domain/Entities/Ref/Address.cs
+++ b/src/VendlyServer.Domain/Entities/Ref/Address.cs
@@ -38,6 +38,9 @@ namespace VendlyServer.Domain.Entities.Ref
         [MaxLength(10)]
         public required string BtsCityCode { get; set; }
 
+        [MaxLength(10)]
+        public string? BtsBranchCode { get; set; }
+
         public bool IsDefault { get; set; }
 
         [ForeignKey(nameof(UserId))]

--- a/src/VendlyServer.Infrastructure/Brokers/BtsExpress/BtsBroker.cs
+++ b/src/VendlyServer.Infrastructure/Brokers/BtsExpress/BtsBroker.cs
@@ -306,24 +306,83 @@ public class BtsBroker(
         var token = await GetAccessTokenAsync(cancellationToken);
         if (token is null) return default;
 
-        var client = CreateHttpClient();
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-
-        var response = await client.GetAsync(path, cancellationToken);
-
-        if (response.StatusCode == HttpStatusCode.Unauthorized && !isRetry)
+        const int maxAttempts = 6;
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
         {
-            await RefreshTokenAsync(cancellationToken);
-            return await SendGetAsync<T>(path, cancellationToken, isRetry: true);
+            try
+            {
+                var client = CreateHttpClient();
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+                var response = await client.GetAsync(path, cancellationToken);
+
+                if (response.StatusCode == HttpStatusCode.Unauthorized && !isRetry)
+                {
+                    await RefreshTokenAsync(cancellationToken);
+                    return await SendGetAsync<T>(path, cancellationToken, isRetry: true);
+                }
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    // Vaqtinchalik xatolar (5xx / 429 / 408) → qayta urinamiz; boshqasi → to'xtaymiz.
+                    if (IsTransient(response.StatusCode) && attempt < maxAttempts)
+                    {
+                        // 429 da server bergan Retry-After ni hurmat qilamiz, aks holda eksponensial backoff.
+                        var delay = response.StatusCode == HttpStatusCode.TooManyRequests
+                            ? RetryAfterMs(response, attempt)
+                            : RetryDelayMs(attempt);
+                        await Task.Delay(delay, cancellationToken);
+                        continue;
+                    }
+
+                    logger.LogWarning("BTS GET {Path} failed with {StatusCode}", path, response.StatusCode);
+                    return default;
+                }
+
+                return await response.Content.ReadFromJsonAsync<T>(cancellationToken);
+            }
+            // Timeout / tarmoq uzilishi — abort qilmaymiz, qayta urinamiz (haqiqiy cancel bundan mustasno).
+            catch (Exception ex) when ((ex is HttpRequestException or TaskCanceledException)
+                                       && !cancellationToken.IsCancellationRequested)
+            {
+                if (attempt >= maxAttempts)
+                {
+                    logger.LogWarning(ex, "BTS GET {Path} failed after {Attempts} attempts", path, attempt);
+                    return default;
+                }
+
+                await Task.Delay(RetryDelayMs(attempt), cancellationToken);
+            }
         }
 
-        if (!response.IsSuccessStatusCode)
+        return default;
+    }
+
+    private static bool IsTransient(HttpStatusCode statusCode) =>
+        statusCode is HttpStatusCode.RequestTimeout            // 408
+            or HttpStatusCode.TooManyRequests                 // 429
+            or HttpStatusCode.InternalServerError             // 500
+            or HttpStatusCode.BadGateway                      // 502
+            or HttpStatusCode.ServiceUnavailable              // 503
+            or HttpStatusCode.GatewayTimeout;                 // 504
+
+    private static int RetryDelayMs(int attempt) => attempt * 500;
+
+    // 429 uchun: server bergan Retry-After (sekund yoki sana) ni ishlatamiz; bo'lmasa
+    // eksponensial backoff (1s, 2s, 4s, 8s ... 30s gacha).
+    private static int RetryAfterMs(HttpResponseMessage response, int attempt)
+    {
+        var retryAfter = response.Headers.RetryAfter;
+        if (retryAfter?.Delta is { } delta && delta > TimeSpan.Zero)
+            return (int)Math.Min(delta.TotalMilliseconds, 30_000);
+
+        if (retryAfter?.Date is { } date)
         {
-            logger.LogWarning("BTS GET {Path} failed with {StatusCode}", path, response.StatusCode);
-            return default;
+            var ms = (date - DateTimeOffset.UtcNow).TotalMilliseconds;
+            if (ms > 0) return (int)Math.Min(ms, 30_000);
         }
 
-        return await response.Content.ReadFromJsonAsync<T>(cancellationToken);
+        return Math.Min(30_000, 1000 * (int)Math.Pow(2, attempt - 1));
     }
 
     private async Task<T?> SendPostAsync<T>(string path, object body, CancellationToken cancellationToken,
@@ -345,7 +404,10 @@ public class BtsBroker(
 
         if (!response.IsSuccessStatusCode)
         {
-            logger.LogWarning("BTS POST {Path} failed with {StatusCode}", path, response.StatusCode);
+            // BTS qaytargan xato matnini ham yozamiz — validation sabablari shu yerda bo'ladi.
+            var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            logger.LogWarning("BTS POST {Path} failed with {StatusCode}: {Body}",
+                path, response.StatusCode, errorBody);
             return default;
         }
 

--- a/src/VendlyServer.Infrastructure/Brokers/BtsExpress/BtsExpressOptions.cs
+++ b/src/VendlyServer.Infrastructure/Brokers/BtsExpress/BtsExpressOptions.cs
@@ -12,8 +12,7 @@ public class BtsExpressOptions
     public string SenderAddress { get; set; } = string.Empty;
     public string SenderCityCode { get; set; } = string.Empty;
     public string SenderBranchCode { get; set; } = string.Empty;
-    public string DefaultPickupType { get; set; } = "self";
-    public string DefaultDropoffType { get; set; } = "courier";
+    public string DefaultPickupType { get; set; } = string.Empty;
     public int DefaultPackageId { get; set; } = 7;
     public int DefaultPostTypeId { get; set; } = 7;
 

--- a/src/VendlyServer.Infrastructure/Persistence/Migrations/20260619000000_Add_Address_BtsBranchCode.Designer.cs
+++ b/src/VendlyServer.Infrastructure/Persistence/Migrations/20260619000000_Add_Address_BtsBranchCode.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using VendlyServer.Infrastructure.Persistence;
@@ -12,9 +13,11 @@ using VendlyServer.Infrastructure.Persistence;
 namespace VendlyServer.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260619000000_Add_Address_BtsBranchCode")]
+    partial class Add_Address_BtsBranchCode
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1032,11 +1035,6 @@ namespace VendlyServer.Infrastructure.Persistence.Migrations
                         .HasColumnType("timestamp with time zone")
                         .HasColumnName("delivered_at");
 
-                    b.Property<string>("DeliveryBtsBranchCode")
-                        .HasMaxLength(10)
-                        .HasColumnType("character varying(10)")
-                        .HasColumnName("delivery_bts_branch_code");
-
                     b.Property<string>("DeliveryBtsCityCode")
                         .IsRequired()
                         .HasMaxLength(10)
@@ -1561,82 +1559,6 @@ namespace VendlyServer.Infrastructure.Persistence.Migrations
                         .HasDatabaseName("ix_payments_order_id");
 
                     b.ToTable("payments", "orders");
-                });
-
-            modelBuilder.Entity("VendlyServer.Domain.Entities.Orders.PaymentTransaction", b =>
-                {
-                    b.Property<long>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint")
-                        .HasColumnName("id");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
-
-                    b.Property<long>("Amount")
-                        .HasColumnType("bigint")
-                        .HasColumnName("amount");
-
-                    b.Property<int?>("CancelReason")
-                        .HasColumnType("integer")
-                        .HasColumnName("cancel_reason");
-
-                    b.Property<DateTimeOffset?>("CancelTime")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("cancel_time");
-
-                    b.Property<DateTimeOffset>("CreateTime")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("create_time");
-
-                    b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("created_at");
-
-                    b.Property<bool>("IsDeleted")
-                        .HasColumnType("boolean")
-                        .HasColumnName("is_deleted");
-
-                    b.Property<long?>("PaymeTime")
-                        .HasColumnType("bigint")
-                        .HasColumnName("payme_time");
-
-                    b.Property<long>("PaymentId")
-                        .HasColumnType("bigint")
-                        .HasColumnName("payment_id");
-
-                    b.Property<DateTimeOffset?>("PerformTime")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("perform_time");
-
-                    b.Property<int>("Provider")
-                        .HasColumnType("integer")
-                        .HasColumnName("provider");
-
-                    b.Property<string>("ProviderTransactionId")
-                        .IsRequired()
-                        .HasMaxLength(64)
-                        .HasColumnType("character varying(64)")
-                        .HasColumnName("provider_transaction_id");
-
-                    b.Property<int>("State")
-                        .HasColumnType("integer")
-                        .HasColumnName("state");
-
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("updated_at");
-
-                    b.HasKey("Id")
-                        .HasName("pk_payment_transactions");
-
-                    b.HasIndex("PaymentId")
-                        .HasDatabaseName("ix_payment_transactions_payment_id");
-
-                    b.HasIndex("Provider", "ProviderTransactionId")
-                        .IsUnique()
-                        .HasDatabaseName("ix_payment_transactions_provider_provider_transaction_id");
-
-                    b.ToTable("payment_transactions", "orders");
                 });
 
             modelBuilder.Entity("VendlyServer.Domain.Entities.Orders.ReturnReason", b =>
@@ -2759,18 +2681,6 @@ namespace VendlyServer.Infrastructure.Persistence.Migrations
                     b.Navigation("Order");
                 });
 
-            modelBuilder.Entity("VendlyServer.Domain.Entities.Orders.PaymentTransaction", b =>
-                {
-                    b.HasOne("VendlyServer.Domain.Entities.Orders.Payment", "Payment")
-                        .WithMany("Transactions")
-                        .HasForeignKey("PaymentId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired()
-                        .HasConstraintName("fk_payment_transactions_payments_payment_id");
-
-                    b.Navigation("Payment");
-                });
-
             modelBuilder.Entity("VendlyServer.Domain.Entities.Orders.ReturnReason", b =>
                 {
                     b.OwnsOne("VendlyServer.Domain.Entities.Common.MultiLanguageField", "Description", b1 =>
@@ -3035,11 +2945,6 @@ namespace VendlyServer.Infrastructure.Persistence.Migrations
             modelBuilder.Entity("VendlyServer.Domain.Entities.Orders.OrderReturn", b =>
                 {
                     b.Navigation("Items");
-                });
-
-            modelBuilder.Entity("VendlyServer.Domain.Entities.Orders.Payment", b =>
-                {
-                    b.Navigation("Transactions");
                 });
 
             modelBuilder.Entity("VendlyServer.Domain.Entities.Public.User", b =>

--- a/src/VendlyServer.Infrastructure/Persistence/Migrations/20260619000000_Add_Address_BtsBranchCode.cs
+++ b/src/VendlyServer.Infrastructure/Persistence/Migrations/20260619000000_Add_Address_BtsBranchCode.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VendlyServer.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_Address_BtsBranchCode : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "bts_branch_code",
+                schema: "ref",
+                table: "addresses",
+                type: "character varying(10)",
+                maxLength: 10,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "bts_branch_code",
+                schema: "ref",
+                table: "addresses");
+        }
+    }
+}

--- a/src/VendlyServer.Infrastructure/Persistence/Migrations/20260619010000_Add_Order_DeliveryBtsBranchCode.Designer.cs
+++ b/src/VendlyServer.Infrastructure/Persistence/Migrations/20260619010000_Add_Order_DeliveryBtsBranchCode.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using VendlyServer.Infrastructure.Persistence;
@@ -12,9 +13,10 @@ using VendlyServer.Infrastructure.Persistence;
 namespace VendlyServer.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260619010000_Add_Order_DeliveryBtsBranchCode")]
+    partial class Add_Order_DeliveryBtsBranchCode
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1563,82 +1565,6 @@ namespace VendlyServer.Infrastructure.Persistence.Migrations
                     b.ToTable("payments", "orders");
                 });
 
-            modelBuilder.Entity("VendlyServer.Domain.Entities.Orders.PaymentTransaction", b =>
-                {
-                    b.Property<long>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint")
-                        .HasColumnName("id");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
-
-                    b.Property<long>("Amount")
-                        .HasColumnType("bigint")
-                        .HasColumnName("amount");
-
-                    b.Property<int?>("CancelReason")
-                        .HasColumnType("integer")
-                        .HasColumnName("cancel_reason");
-
-                    b.Property<DateTimeOffset?>("CancelTime")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("cancel_time");
-
-                    b.Property<DateTimeOffset>("CreateTime")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("create_time");
-
-                    b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("created_at");
-
-                    b.Property<bool>("IsDeleted")
-                        .HasColumnType("boolean")
-                        .HasColumnName("is_deleted");
-
-                    b.Property<long?>("PaymeTime")
-                        .HasColumnType("bigint")
-                        .HasColumnName("payme_time");
-
-                    b.Property<long>("PaymentId")
-                        .HasColumnType("bigint")
-                        .HasColumnName("payment_id");
-
-                    b.Property<DateTimeOffset?>("PerformTime")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("perform_time");
-
-                    b.Property<int>("Provider")
-                        .HasColumnType("integer")
-                        .HasColumnName("provider");
-
-                    b.Property<string>("ProviderTransactionId")
-                        .IsRequired()
-                        .HasMaxLength(64)
-                        .HasColumnType("character varying(64)")
-                        .HasColumnName("provider_transaction_id");
-
-                    b.Property<int>("State")
-                        .HasColumnType("integer")
-                        .HasColumnName("state");
-
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("updated_at");
-
-                    b.HasKey("Id")
-                        .HasName("pk_payment_transactions");
-
-                    b.HasIndex("PaymentId")
-                        .HasDatabaseName("ix_payment_transactions_payment_id");
-
-                    b.HasIndex("Provider", "ProviderTransactionId")
-                        .IsUnique()
-                        .HasDatabaseName("ix_payment_transactions_provider_provider_transaction_id");
-
-                    b.ToTable("payment_transactions", "orders");
-                });
-
             modelBuilder.Entity("VendlyServer.Domain.Entities.Orders.ReturnReason", b =>
                 {
                     b.Property<long>("Id")
@@ -2759,18 +2685,6 @@ namespace VendlyServer.Infrastructure.Persistence.Migrations
                     b.Navigation("Order");
                 });
 
-            modelBuilder.Entity("VendlyServer.Domain.Entities.Orders.PaymentTransaction", b =>
-                {
-                    b.HasOne("VendlyServer.Domain.Entities.Orders.Payment", "Payment")
-                        .WithMany("Transactions")
-                        .HasForeignKey("PaymentId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired()
-                        .HasConstraintName("fk_payment_transactions_payments_payment_id");
-
-                    b.Navigation("Payment");
-                });
-
             modelBuilder.Entity("VendlyServer.Domain.Entities.Orders.ReturnReason", b =>
                 {
                     b.OwnsOne("VendlyServer.Domain.Entities.Common.MultiLanguageField", "Description", b1 =>
@@ -3035,11 +2949,6 @@ namespace VendlyServer.Infrastructure.Persistence.Migrations
             modelBuilder.Entity("VendlyServer.Domain.Entities.Orders.OrderReturn", b =>
                 {
                     b.Navigation("Items");
-                });
-
-            modelBuilder.Entity("VendlyServer.Domain.Entities.Orders.Payment", b =>
-                {
-                    b.Navigation("Transactions");
                 });
 
             modelBuilder.Entity("VendlyServer.Domain.Entities.Public.User", b =>

--- a/src/VendlyServer.Infrastructure/Persistence/Migrations/20260619010000_Add_Order_DeliveryBtsBranchCode.cs
+++ b/src/VendlyServer.Infrastructure/Persistence/Migrations/20260619010000_Add_Order_DeliveryBtsBranchCode.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VendlyServer.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_Order_DeliveryBtsBranchCode : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "delivery_bts_branch_code",
+                schema: "orders",
+                table: "orders",
+                type: "character varying(10)",
+                maxLength: 10,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "delivery_bts_branch_code",
+                schema: "orders",
+                table: "orders");
+        }
+    }
+}

--- a/tests/VendlyServer.Tests/Services/AddressServiceTests.cs
+++ b/tests/VendlyServer.Tests/Services/AddressServiceTests.cs
@@ -39,6 +39,7 @@ public class AddressServiceTests : IDisposable
             House: "12",
             Extra: null,
             BtsCityCode: btsCityCode,
+            BtsBranchCode: null,
             IsDefault: isDefault);
 
     private Address Seed(long userId, string label = "Old", bool isDefault = false, bool isDeleted = false, string btsCityCode = ValidCityCode)
@@ -185,6 +186,7 @@ public class AddressServiceTests : IDisposable
             House: "55",
             Extra: "Apartment 4",
             BtsCityCode: OtherCityCode,
+            BtsBranchCode: null,
             IsDefault: false));
 
         Assert.True(result.IsSuccess);
@@ -200,7 +202,7 @@ public class AddressServiceTests : IDisposable
         var result = await _service.UpdateAsync(UserA, stranger.Id, new UpdateAddressRequest(
             Label: "Hijack",
             City: "x", District: "x", Street: "x", House: "1", Extra: null,
-            BtsCityCode: ValidCityCode, IsDefault: false));
+            BtsCityCode: ValidCityCode, BtsBranchCode: null, IsDefault: false));
 
         Assert.False(result.IsSuccess);
         Assert.Equal(AddressErrors.NotFound, result.Error);
@@ -213,7 +215,7 @@ public class AddressServiceTests : IDisposable
 
         var result = await _service.UpdateAsync(UserA, own.Id, new UpdateAddressRequest(
             Label: "X", City: "X", District: "X", Street: "X", House: "1", Extra: null,
-            BtsCityCode: "9999", IsDefault: false));
+            BtsCityCode: "9999", BtsBranchCode: null, IsDefault: false));
 
         Assert.False(result.IsSuccess);
         Assert.Equal(AddressErrors.BtsCityCodeInvalid, result.Error);


### PR DESCRIPTION
- Address/Order: add BtsBranchCode/DeliveryBtsBranchCode (+ migrations)
- Shipping: IShippingCalculatorService via BTS calculate; quote endpoints
- Orders: compute delivery cost from cart weight, block zero-weight, branch dropoff
- BtsRef: branches by city/region endpoints
- BtsCatalogSync: dedup-dict fix, skip empty codes, 429 retry + throttle
- BtsBroker: transient retry/backoff (GET), error-body logging (POST)
- SmartupSync: persist weight_brutto -> ProductMeasurement.WeightKg
- OrderShipping: verified BTS order create; null tracking guard